### PR TITLE
Remove dependency on Qt5.1

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -3,7 +3,6 @@ SET(base_files
 	../COPYING
 	../README.md
 	openraster.txt
-	textloader.txt
 )
 
 SET(man1

--- a/src/client/canvasview.cpp
+++ b/src/client/canvasview.cpp
@@ -18,7 +18,6 @@
    Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#include <QtMath>
 #include <QMouseEvent>
 #include <QTabletEvent>
 #include <QScrollBar>
@@ -420,6 +419,11 @@ void CanvasView::scrollTo(const QPoint& point)
 	sceneChanged();
 }
 
+inline float qRadiansToDegrees(float radians)
+{
+    return radians * float(180/M_PI);
+}
+
 /**
  * @param x x coordinate
  * @param y y coordinate
@@ -430,8 +434,8 @@ void CanvasView::moveDrag(int x, int y)
 	const int dy = _dragy - y;
 
 	if(_isdragging==ROTATE) {
-		qreal preva = qAtan2( width()/2 - _dragx, height()/2 - _dragy );
-		qreal a = qAtan2( width()/2 - x, height()/2 - y );
+		qreal preva = atan2( width()/2 - _dragx, height()/2 - _dragy );
+		qreal a = atan2( width()/2 - x, height()/2 - y );
 		setRotation(rotation() + qRadiansToDegrees(preva-a));
 	} else {
 		QScrollBar *ver = verticalScrollBar();

--- a/src/client/ora/qzip.cpp
+++ b/src/client/ora/qzip.cpp
@@ -44,7 +44,8 @@
 #include "zipreader.h"
 #include "zipwriter.h"
 #include <qdatetime.h>
-#include <qplatformdefs.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <qendian.h>
 #include <qdebug.h>
 #include <qdir.h>

--- a/src/client/textloader.cpp
+++ b/src/client/textloader.cpp
@@ -85,7 +85,7 @@ uint str2color(const QString &str) {
 	if(str.at(0) == '#')
 	{
 		bool ok;
-		uint i = str.midRef(1).toUInt(&ok, 16);
+		uint i = str.mid(1).toUInt(&ok, 16);
 		if(!ok)
 			throw SyntaxError(QString("'%1'' is not an integer!").arg(str));
 		return i;

--- a/src/client/widgets/brushpreview.cpp
+++ b/src/client/widgets/brushpreview.cpp
@@ -18,7 +18,6 @@
    Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 #include <QDebug>
-#include <QtMath>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QEvent>
@@ -136,7 +135,7 @@ void BrushPreview::updatePreview()
 
 			const qreal fx = x/qreal(strokew);
 			const qreal pressure = qBound(0.0, ((fx*fx) - (fx*fx*fx))*6.756, 1.0);
-			const int y = qRound(qSin(phase) * strokeh);
+			const int y = qRound(sin(phase) * strokeh);
 			layer->drawLine(0, brush_,
 					dpcore::Point(offx+lastx,offy+lasty, lastp),
 					dpcore::Point(offx+x, offy+y, pressure), distance);


### PR DESCRIPTION
Makes drawpile 0.7.1 compile with only Qt5.0.

Also removes a missing file from the install target.

Fixes https://github.com/callaa/Drawpile/issues/9
