### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies:
 
 For building just the dedicated server, only QtCore and QtNetwork are required.
 
-It's a good idead to build in a separate directory to keep build files
+It's a good idea to build in a separate directory to keep build files
 separate from the source tree.
 
 Example:


### PR DESCRIPTION
In the README under building instructions, corrected 'idead' to 'idea'.
