### PR TITLE
Include QStringList

### DIFF
--- a/src/shared/server/opcommands.cpp
+++ b/src/shared/server/opcommands.cpp
@@ -23,6 +23,7 @@
 #include "../net/meta.h"
 
 #include <QList>
+#include <QStringList>
 
 namespace server {
 


### PR DESCRIPTION
Otherwise it won't compile on some systems.

```
[ 34%] Building CXX object src/shared/CMakeFiles/drawpilenet.dir/server/opcommands.cpp.o
/home/p/Drawpile/src/shared/server/opcommands.cpp: In function 'void server::{anonymous}::lockBoard(server::Client*, const QString&, const QStringList&)':
/home/p/Drawpile/src/shared/server/opcommands.cpp:90:37: error: invalid use of incomplete type 'const class QStringList'
  client->session()->setLocked(tokens.size()==1 || _getOnOff(tokens.at(1)));
                                     ^
In file included from /usr/include/qt5/QtCore/qobject.h:49:0,
                 from /usr/include/qt5/QtCore/QObject:1,
                 from /home/p/Drawpile/src/shared/server/client.h:22,
                 from /home/p/Drawpile/src/shared/server/opcommands.cpp:21:
/usr/include/qt5/QtCore/qstring.h:75:7: error: forward declaration of 'const class QStringList'
 class QStringList;
```
