### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/desktop/drawpile.desktop
+++ b/desktop/drawpile.desktop
@@ -1,12 +1,10 @@
 [Desktop Entry]
 Version=1.0
 Name=Drawpile
-
 GenericName=Collaborative Drawing Program
 GenericName[fi]=Monen käyttäjän piirto-ohjelma
-
 Exec=drawpile %u
-MimeType=image/openraster;image/png;image/jpeg;application/x-drawpile-recording;x-scheme-handler/drawpile
+MimeType=image/openraster;image/png;image/jpeg;application/x-drawpile-recording;x-scheme-handler/drawpile;
 Type=Application
 Icon=drawpile
 StartupNotify=true


### PR DESCRIPTION
`desktop-file-validate` currently says: `drawpile.desktop: error: value "image/openraster;image/png;image/jpeg;application/x-drawpile-recording;x-scheme-handler/drawpile" for string list key "MimeType" in group "Desktop Entry" does not have a semicolon (';') as trailing character`