### PR TITLE
mention Dockerfile in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Client specific dependencies:
 * GIFLIB (optional: animated GIF export)
 * MiniUPnP (optional: automatic port forwarding setup)
 
-Server specific dependencies:
+Server specific dependencies (you can also take a look at [Docker build](server/docker/Dockerfile) script):
 
 * libsystemd (optional: systemd socket activation support)
 * libmicrohttpd (optional: HTTP admin API)


### PR DESCRIPTION
Dockerfile helps a lot when building on Debian/Ubuntu. The `apt-get install` line is pretty re-usable.