### PR TITLE
Doubleclick closes pin

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -74,6 +74,7 @@ set (
 	docks/layeraclmenu.cpp
 	docks/inputsettingsdock.cpp
 	chat/chatlineedit.cpp
+	chat/chatwidgetpinnedarea.cpp
 	chat/chatwidget.cpp 
 	chat/useritemdelegate.cpp
 	chat/chatbox.cpp

--- a/src/desktop/chat/chatwidget.cpp
+++ b/src/desktop/chat/chatwidget.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "chatlineedit.h"
+#include "chatwidgetpinnedarea.h"
 #include "chatwidget.h"
 #include "utils/html.h"
 #include "utils/funstuff.h"
@@ -85,7 +86,7 @@ struct ChatWidget::Private {
 	ChatWidget * const chatbox;
 	QTextBrowser *view = nullptr;
 	ChatLineEdit *myline = nullptr;
-	QLabel *pinned = nullptr;
+	ChatWidgetPinnedArea *pinned = nullptr;
 	QTabBar *tabs = nullptr;
 
 	QList<int> announcedUsers;
@@ -152,16 +153,7 @@ ChatWidget::ChatWidget(QWidget *parent)
 	connect(d->tabs, &QTabBar::tabCloseRequested, this, &ChatWidget::chatTabClosed);
 	layout->addWidget(d->tabs, 0);
 
-	d->pinned = new QLabel(this);
-	d->pinned->setVisible(false);
-	d->pinned->setOpenExternalLinks(true);
-	d->pinned->setWordWrap(true);
-	d->pinned->setStyleSheet(QStringLiteral(
-		"background: #232629;"
-		"border-bottom: 1px solid #2980b9;"
-		"color: #eff0f1;"
-		"padding: 3px;"
-		));
+	d->pinned = new ChatWidgetPinnedArea(this);
 	layout->addWidget(d->pinned, 0);
 
 	d->view = new QTextBrowser(this);
@@ -554,17 +546,7 @@ void ChatWidget::receiveMessage(const protocol::MessagePtr &msg)
 		const QString safetext = chat.message().toHtmlEscaped();
 
 		if(chat.isPin()) {
-			if(safetext == "-") {
-				// note: the protocol doesn't allow empty chat messages,
-				// which is why we have to use a special value like this
-				// to clear the pinning.
-				d->pinned->setVisible(false);
-				d->pinned->setText(QString());
-			} else {
-				d->pinned->setText(htmlutils::linkify(safetext, QStringLiteral("style=\"color:#3daae9\"")));
-				d->pinned->setVisible(true);
-			}
-
+			d->pinned->setPinText(safetext);
 		} else if(chat.isAction()) {
 			d->publicChat().appendAction(d->usernameSpan(msg->contextId()), htmlutils::linkify(safetext));
 

--- a/src/desktop/chat/chatwidgetpinnedarea.cpp
+++ b/src/desktop/chat/chatwidgetpinnedarea.cpp
@@ -1,0 +1,61 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2013-2014 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chatwidgetpinnedarea.h"
+#include "utils/html.h"
+
+namespace widgets {
+
+ChatWidgetPinnedArea::ChatWidgetPinnedArea(QWidget *parent) :
+	QLabel(parent)
+{
+	setVisible(false);
+	setOpenExternalLinks(true);
+	setWordWrap(true);
+	setStyleSheet(QStringLiteral(
+		"background: #232629;"
+		"border-bottom: 1px solid #2980b9;"
+		"color: #eff0f1;"
+		"padding: 3px;"
+					  ));
+}
+
+void ChatWidgetPinnedArea::setPinText(const QString &safetext)
+{
+	if(safetext == "-") {
+		// note: the protocol doesn't allow empty chat messages,
+		// which is why we have to use a special value like this
+		// to clear the pinning.
+		setVisible(false);
+		setText(QString());
+	} else {
+		const QString htmltext = htmlutils::linkify(safetext, QStringLiteral("style=\"color:#3daae9\""));
+		if (QString::compare(text(), htmltext)) {
+			setText(htmltext);
+			setVisible(true);
+		}
+	}
+}
+
+void ChatWidgetPinnedArea::mouseDoubleClickEvent(QMouseEvent *)
+{
+	setVisible(false);
+}
+
+}

--- a/src/desktop/chat/chatwidgetpinnedarea.h
+++ b/src/desktop/chat/chatwidgetpinnedarea.h
@@ -1,0 +1,40 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2013-2014 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHATWIDGETPINNEDAREA_H
+#define CHATWIDGETPINNEDAREA_H
+
+#include <QLabel>
+
+namespace widgets {
+
+class ChatWidgetPinnedArea : public QLabel
+{
+	Q_OBJECT
+public:
+	explicit ChatWidgetPinnedArea(QWidget *parent = nullptr);
+	void setPinText(const QString &);
+
+protected:
+	void mouseDoubleClickEvent(QMouseEvent *event);
+};
+
+}
+
+#endif // CHATWIDGETPINNEDAREA_H


### PR DESCRIPTION
#### Rationale:
* Users could use the ability to close the announcement message once it's been read, it takes precious vertical space with a static notice, you should only need to awknowledge it once.

#### Implementation:
* Double clicking a pin will hide it until the text changes or the user reconnects.