### PR TITLE
Fix favicon download not saving to conf

### DIFF
--- a/src/desktop/dialogs/joindialog.cpp
+++ b/src/desktop/dialogs/joindialog.cpp
@@ -483,6 +483,7 @@ void JoinDialog::addListServer()
 
 					sessionlisting::ListServerModel listservers(true);
 					listservers.setFavicon(apiUrl, image);
+					listservers.saveServers();
 				});
 				connect(filedownload, &networkaccess::FileDownload::finished, filedownload, &QObject::deleteLater);
 


### PR DESCRIPTION
connect is an asynchronous operation, the code will run after the image url is loaded. It's not saving the changes made by setFavicon into drawpile.conf.