### PR TITLE
Fix zoom in not working at certain zoom levels.

### DIFF
--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -124,9 +124,9 @@ void CanvasView::scrollBy(int x, int y)
 void CanvasView::zoomSteps(int steps)
 {
 	if(m_zoom<100 || (m_zoom==100 && steps<0))
-		setZoom(qRound((m_zoom + steps * 10) / 10) * 10);
+		setZoom(qRound(qMin(qreal(100), m_zoom + steps * 10) / 10) * 10);
 	else
-		setZoom(qRound((m_zoom + steps * 50) / 50) * 50);
+		setZoom(qRound(qMax(qreal(100), m_zoom + steps * 50) / 50) * 50);
 	viewRectChanged();
 }
 


### PR DESCRIPTION
This pr is a minimal change to the CanvasView::zoomSteps function to fix the cases where the zoom level does not change.

Specifically, when using the right mouse button, where the zoom step is -3, the zoom level will not change when its in the range `[100, 175]`.

What this change essentially does is make it not skip over 100% when zooming in or out.

A few comparisons between old and new behavior

| zoom_step | m_zoom | m_zoom after (old behavior)| m_zoom after (new behavior) |
| --- | --- | --- | --- |
| -1 | 110 | 50 | 100 |
| -1 | 100 | 90 | 90 |
| -3 | 110 | -50 (wont change) | 100 |
| 1  | 90  | 100 | 100 |
| 3  | 90  | 120 | 100 |
