### PR TITLE
Fix brush size adjust shortcuts not updating brush size correctly

### DIFF
--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -500,9 +500,10 @@ void BrushSettings::setForeground(const QColor& color)
 void BrushSettings::quickAdjust1(qreal adjustment)
 {
 	d->quickAdjust1 += adjustment;
-	if(qAbs(d->quickAdjust1) >= 1.0) {
-		qreal i;
-		d->quickAdjust1 = modf(d->quickAdjust1, &i);
+	qreal i;
+	qreal f = modf(d->quickAdjust1, &i);
+	if(int(i)) {
+		d->quickAdjust1 = f;
 		d->ui.brushsizeBox->setValue(d->ui.brushsizeBox->value() + int(i));
 	}
 }

--- a/src/desktop/toolwidgets/colorpickersettings.cpp
+++ b/src/desktop/toolwidgets/colorpickersettings.cpp
@@ -109,9 +109,10 @@ int ColorPickerSettings::getSize() const
 void ColorPickerSettings::quickAdjust1(qreal adjustment)
 {
 	m_quickAdjust1 += adjustment;
-	if(qAbs(m_quickAdjust1) > 1.0) {
-		qreal i;
-		m_quickAdjust1 = modf(m_quickAdjust1, &i);
+	qreal i;
+	qreal f = modf(m_quickAdjust1, &i);
+	if(int(i)) {
+		m_quickAdjust1 = f;
 		m_size->setValue(m_size->value() + int(i));
 	}
 }

--- a/src/desktop/toolwidgets/fillsettings.cpp
+++ b/src/desktop/toolwidgets/fillsettings.cpp
@@ -123,9 +123,10 @@ void FillSettings::restoreToolSettings(const ToolProperties &cfg)
 void FillSettings::quickAdjust1(qreal adjustment)
 {
 	m_quickAdjust1 += adjustment;
-	if(qAbs(m_quickAdjust1) > 1.0) {
-		qreal i;
-		m_quickAdjust1 = modf(m_quickAdjust1, &i);
+	qreal i;
+	qreal f = modf(m_quickAdjust1, &i);
+	if(int(i)) {
+		m_quickAdjust1 = f;
 		_ui->tolerance->setValue(_ui->tolerance->value() + int(i));
 	}
 }

--- a/src/desktop/toolwidgets/lasersettings.cpp
+++ b/src/desktop/toolwidgets/lasersettings.cpp
@@ -128,9 +128,10 @@ void LaserPointerSettings::setForeground(const QColor &color)
 void LaserPointerSettings::quickAdjust1(qreal adjustment)
 {
 	m_quickAdjust1 += adjustment;
-	if(qAbs(m_quickAdjust1) > 1.0) {
-		qreal i;
-		m_quickAdjust1 = modf(m_quickAdjust1, &i);
+	qreal i;
+	qreal f = modf(m_quickAdjust1, &i);
+	if(int(i)) {
+		m_quickAdjust1 = f;
 		_ui->persistence->setValue(_ui->persistence->value() + int(i));
 	}
 }


### PR DESCRIPTION
currently on my computer, updating the brush(or whichever tool it is) size via the [ or ] keys requires 2 key presses to show any effect, and will change brush size by 2 when it does.

The change is to compare the integer component of m_quickAdjust1 directly to avoid any floating point comparisions, which seem to be the cause of the issue.

This also makes all the quickAdjust1 overrides consistent, before they differed in whether the comparison was `>= 1.0` or `> 1.0`.