### PR TITLE
Fix being unable to move entire canvas

### DIFF
--- a/src/libclient/canvas/statetracker.cpp
+++ b/src/libclient/canvas/statetracker.cpp
@@ -710,8 +710,9 @@ void StateTracker::handleMoveRegion(const protocol::MoveRegion &cmd)
 	});
 
 	// Sanity check: without a size limit, a user could create huge temporary images and potentially other clients
-	const int targetArea = target.boundingRect().size().width() * target.boundingRect().size().height();
-	if(targetArea > m_layerstack->width() * m_layerstack->height()) {
+	const auto targetSize = target.boundingRect().size();
+	const int targetArea = targetSize.width() * targetSize.height();
+	if(targetArea > (m_layerstack->width()+1) * (m_layerstack->height()+1)) {
 		qWarning("moveRegion: cannot scale beyond image size");
 		return;
 	}


### PR DESCRIPTION
selection range is exclusive, so width and height of selection are one bigger then the canvas size.

adds 1 to width and height when calculating the sanity check

I havent tested it in a online session yet, so not sure if this is something that requires all clients/server to agree upon or not to avoid inconsistencies, which may be an issue.