### PR TITLE
Fix closed selections being initially unclosed

### DIFF
--- a/src/libclient/canvas/selection.cpp
+++ b/src/libclient/canvas/selection.cpp
@@ -306,6 +306,15 @@ void Selection::addPointToShape(const QPointF &point)
 	}
 }
 
+void Selection::closeShape()
+{
+	if(!m_closedPolygon) {
+		m_closedPolygon = true;
+		saveShape();
+		emit closed();
+	}
+}
+
 bool Selection::closeShape(const QRectF &clipRect)
 {
 	if(!m_closedPolygon) {
@@ -377,6 +386,7 @@ void Selection::setPasteImage(const QImage &image)
 		setShapeRect(QRect(c.x() - image.width()/2, c.y()-image.height()/2, image.width(), image.height()));
 	}
 
+	closeShape();
 	m_pasteImage = image;
 	emit pasteImageChanged(image);
 }

--- a/src/libclient/canvas/selection.h
+++ b/src/libclient/canvas/selection.h
@@ -58,6 +58,9 @@ public:
 	//! Add a point to the selection polygon. The shape must be open
 	void addPointToShape(const QPointF &point);
 
+	//! Close the selection
+	void closeShape();
+
 	/**
 	 * Close the selection and clip it to the given rectangle
 	 * @param clipRect rectangle that represents the working area

--- a/src/libclient/document.cpp
+++ b/src/libclient/document.cpp
@@ -779,6 +779,7 @@ void Document::selectAll()
 
 	canvas::Selection *selection = new canvas::Selection;
 	selection->setShapeRect(QRect(QPoint(), m_canvas->layerStack()->size()));
+	selection->closeShape();
 	m_canvas->setSelection(selection);
 }
 


### PR DESCRIPTION
Fixes #881 
Currently the selections created by pasting and "Select All" start unclosed.
Once moved/clicked the `Selection::closeShape(clipRect)` function is called, which distorts the image.

These selections which are complete from the start should be closed on creation, 
This fix adds back the `Selection::closeShape()` function that does not clip, and uses that for the above commands on creation of the Selection.

There may be other such selections that have this behavior that may need to be fixed in the same way.