### PR TITLE
Color picker cursor fix

### DIFF
--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -491,6 +491,8 @@ void CanvasView::onPenUp()
 		emit penUp();
 
 	m_penmode = PenMode::Normal;
+	resetCursor();
+	updateOutline();
 }
 
 void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus)


### PR DESCRIPTION
Fixes #839 

The cursor would still have color picker cursor after color picking and moving at the same time. This commit resets the cursor when the pen is lifted or no longer in color picking mode. 

This is my first pull request, so it's pretty small and I'm trying figure things out. 