### PR TITLE
Set initial format for annotation content

### DIFF
--- a/src/desktop/toolwidgets/annotationsettings.cpp
+++ b/src/desktop/toolwidgets/annotationsettings.cpp
@@ -115,6 +115,13 @@ QWidget *AnnotationSettings::createUiWidget(QWidget *parent)
 		}
 	}
 
+	// Set initial content format
+	QTextCharFormat fmt;
+	fmt.setFontFamily(_ui->font->currentText());
+	fmt.setFontPointSize(_ui->size->value());
+	fmt.setForeground(_ui->btnTextColor->color());
+	_ui->content->setCurrentCharFormat(fmt);
+
 	setUiEnabled(false);
 
 	return widget;


### PR DESCRIPTION
Current behavior is that when using the annotation tool for the first time, creating a new annotation, the contents of the `ui->content` do not use the expected default format as shown in the formatting settings.

This PR will explicitly set the right font family, size, and color to the expected values.
This PR also adds the `QPainterPath` header to 2 files in order to compile correctly.
