### PR TITLE
Resize canvas with given selection

### DIFF
--- a/src/desktop/dialogs/resizedialog.cpp
+++ b/src/desktop/dialogs/resizedialog.cpp
@@ -64,6 +64,19 @@ void ResizeDialog::setPreviewImage(const QImage &image)
 	m_ui->resizer->setImage(image);
 }
 
+void ResizeDialog::setBounds(const QRect &rect)
+{
+	auto rectIn = rect.intersected({{0,0}, m_ui->resizer->originalSize()});
+
+	m_aspectratio = rectIn.width() / float(rectIn.height());
+
+	m_ui->width->setValue(rectIn.width());
+	m_ui->height->setValue(rectIn.height());
+
+	m_ui->resizer->setOffset(-rectIn.topLeft());
+	m_ui->resizer->setTargetSize(rectIn.size());
+}
+
 void ResizeDialog::done(int r)
 {
 	if(r == QDialog::Accepted) {

--- a/src/desktop/dialogs/resizedialog.h
+++ b/src/desktop/dialogs/resizedialog.h
@@ -41,6 +41,7 @@ public:
 	~ResizeDialog();
 
 	void setPreviewImage(const QImage &image);
+	void setBounds(const QRect &rect);
 
 	QSize newSize() const;
 	QPoint newOffset() const;

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -2100,7 +2100,14 @@ void MainWindow::resizeCanvas()
 	dlg->setPreviewImage(m_doc->canvas()->toImage().scaled(300, 300, Qt::KeepAspectRatio));
 	dlg->setAttribute(Qt::WA_DeleteOnClose);
 
+	if (m_doc->canvas()->selection()) {
+		dlg->setBounds(m_doc->canvas()->selection()->boundingRect());
+	}
+
 	connect(dlg, &QDialog::accepted, this, [this, dlg]() {
+		if (m_doc->canvas()->selection()) {
+			m_doc->canvas()->setSelection(nullptr);
+		}
 		dialogs::ResizeVector r = dlg->resizeVector();
 		if(!r.isZero()) {
 			m_doc->sendResizeCanvas(r.top, r.right, r.bottom, r.left);


### PR DESCRIPTION
- Allows the user to select an area and then follow with `Edit > Resize Canvas...`, the selection will be carried over to the widget. Makes resizing easier and accurate.
- Clears the selection before resize to prevent weird undo.
- This PR won't compile without the QPainterPath include fixes.