### PR TITLE
Mark layers dirty after removing previews

### DIFF
--- a/src/libclient/core/layerstack.cpp
+++ b/src/libclient/core/layerstack.cpp
@@ -742,7 +742,9 @@ void EditableLayerStack::reset()
 void EditableLayerStack::removePreviews()
 {
 	for(Layer *l : d->m_layers) {
-		EditableLayer(l, d, contextId).removePreviews();
+		EditableLayer el(l, d, contextId);
+		el.removePreviews();
+		el.markOpaqueDirty();
 	}
 }
 


### PR DESCRIPTION
Fixes #940.

May be a little heavy-handed since it just marks all layers dirty I think. Only marking the layer dirty where the preview was removed from doesn't work though, so this is my solution for now.