### PR TITLE
Allow different input settings per brush

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -12,6 +12,7 @@ set (
 	main.cpp
 	mainwindow.cpp
 	notifications.cpp
+	inputpresetmodel.cpp
 	toolwidgets/toolsettings.cpp
 	toolwidgets/brushsettings.cpp
 	toolwidgets/colorpickersettings.cpp

--- a/src/desktop/docks/inputsettingsdock.cpp
+++ b/src/desktop/docks/inputsettingsdock.cpp
@@ -22,16 +22,16 @@
 
 #include "ui_inputcfg.h"
 
-#include <QSettings>
+#include <QDebug>
+#include <QInputDialog>
+#include <QUuid>
 
 namespace docks {
 
-namespace {
-	int center(const QSlider *slider) { return (slider->maximum() - slider->minimum()) / 2 + slider->minimum(); }
-}
-
-InputSettings::InputSettings(QWidget *parent) :
-	QDockWidget(tr("Input"), parent)
+InputSettings::InputSettings(input::PresetModel *presetModel, QWidget *parent) :
+	QDockWidget(tr("Input"), parent),
+	m_presetModel(presetModel),
+	m_updateInProgress(false)
 {
 	m_ui = new Ui_InputSettings;
 	QWidget *w = new QWidget(this);
@@ -40,36 +40,18 @@ InputSettings::InputSettings(QWidget *parent) :
 
 	setStyleSheet(defaultDockStylesheet());
 
-	// Restore settings
-	QSettings cfg;
-	cfg.beginGroup("input");
-	m_ui->smoothing->setValue(cfg.value("smoothing", center(m_ui->smoothing)).toInt());
-	m_ui->pressuresrc->setCurrentIndex(cfg.value("pressuremode", 0).toInt());
-	m_ui->stackedWidget->setCurrentIndex(m_ui->pressuresrc->currentIndex());
+	m_presetmenu = new QMenu(this);
+	m_addPresetAction = m_presetmenu->addAction(tr("Add preset"), this, &InputSettings::addPreset);
+	m_renamePresetAction = m_presetmenu->addAction(tr("Rename preset"), this, &InputSettings::renamePreset);
+	m_removePresetAction = m_presetmenu->addAction(tr("Remove preset"), this, &InputSettings::removePreset);
+	m_ui->presetButton->setMenu(m_presetmenu);
 
-	if(cfg.contains("pressurecurve")) {
-		KisCubicCurve curve;
-		curve.fromString(cfg.value("pressurecurve").toString());
-		m_ui->stylusCurve->setCurve(curve);
-	}
-
-	if(cfg.contains("distancecurve")) {
-		KisCubicCurve curve;
-		curve.fromString(cfg.value("distancecurve").toString());
-		m_ui->distanceCurve->setCurve(curve);
-	}
-
-	if(cfg.contains("velocitycurve")) {
-		KisCubicCurve curve;
-		curve.fromString(cfg.value("velocitycurve").toString());
-		m_ui->velocityCurve->setCurve(curve);
-	}
-
-	m_ui->distance->setValue(cfg.value("distance", center(m_ui->distance)).toInt());
-	m_ui->velocity->setValue(cfg.value("velocity", center(m_ui->velocity)).toInt());
+	m_ui->preset->setModel(m_presetModel);
+	m_ui->preset->setCurrentIndex(0);
+	choosePreset(m_ui->preset->currentIndex());
 
 	// Make connections
-	connect(m_ui->smoothing, SIGNAL(valueChanged(int)), this, SIGNAL(smoothingChanged(int)));
+	connect(m_ui->smoothing, &QSlider::valueChanged, this, &InputSettings::updateSmoothing);
 
 	connect(m_ui->stylusCurve, &KisCurveWidget::curveChanged, this, &InputSettings::updatePressureMapping);
 	connect(m_ui->distanceCurve, &KisCurveWidget::curveChanged, this, &InputSettings::updatePressureMapping);
@@ -78,59 +60,123 @@ InputSettings::InputSettings(QWidget *parent) :
 	connect(m_ui->pressuresrc, SIGNAL(currentIndexChanged(int)), this, SLOT(updatePressureMapping()));
 	connect(m_ui->distance, SIGNAL(valueChanged(int)), this, SLOT(updatePressureMapping()));
 	connect(m_ui->velocity, SIGNAL(valueChanged(int)), this, SLOT(updatePressureMapping()));
+
+	connect(m_ui->preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &InputSettings::choosePreset);
+	connect(m_presetModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)), this, SLOT(presetDataChanged(QModelIndex,QModelIndex)));
 }
 
 InputSettings::~InputSettings()
 {
-	// Save settings
-	QSettings cfg;
-	cfg.beginGroup("input");
-
-	cfg.setValue("smoothing", m_ui->smoothing->value());
-	cfg.setValue("pressuremode", m_ui->pressuresrc->currentIndex());
-	cfg.setValue("pressurecurve", m_ui->stylusCurve->curve().toString());
-	cfg.setValue("distancecurve", m_ui->distanceCurve->curve().toString());
-	cfg.setValue("velocitycurve", m_ui->velocityCurve->curve().toString());
-	cfg.setValue("distance", m_ui->distance->value());
-	cfg.setValue("velocity", m_ui->velocity->value());
-
-	// Clean up
 	delete m_ui;
 }
 
-int InputSettings::getSmoothing() const
+
+input::Preset *InputSettings::mutableCurrentPreset()
 {
-	return m_ui->smoothing->value();
+	return (*m_presetModel)[m_ui->preset->currentIndex()];
 }
 
-PressureMapping InputSettings::getPressureMapping() const
+const input::Preset *InputSettings::currentPreset() const
 {
-	PressureMapping pm;
+	return m_presetModel->at(m_ui->preset->currentIndex());
+}
 
-	switch(m_ui->pressuresrc->currentIndex()) {
-	case 0:
-		pm.mode = PressureMapping::STYLUS;
-		pm.curve = m_ui->stylusCurve->curve();
-		pm.param = 0;
-		break;
-	case 1:
-		pm.mode = PressureMapping::DISTANCE;
-		pm.curve = m_ui->distanceCurve->curve();
-		pm.param = m_ui->distance->value();
-		break;
-	case 2:
-		pm.mode = PressureMapping::VELOCITY;
-		pm.curve = m_ui->velocityCurve->curve();
-		pm.param = m_ui->velocity->value();
-		break;
+void InputSettings::updateSmoothing()
+{
+	input::Preset *preset = mutableCurrentPreset();
+	if(preset) {
+		applyUiToPreset(*preset);
 	}
-
-	return pm;
 }
 
 void InputSettings::updatePressureMapping()
 {
-	emit pressureMappingChanged(getPressureMapping());
+	input::Preset *preset = mutableCurrentPreset();
+	if(preset) {
+		applyUiToPreset(*preset);
+	}
+}
+
+void InputSettings::choosePreset(int index)
+{
+	const input::Preset *preset = m_presetModel->at(index);
+	if(preset) {
+		applyPresetToUi(*preset);
+		updatePresetMenu();
+	}
+}
+
+void InputSettings::addPreset()
+{
+	const input::Preset &preset = m_presetModel->add(currentPreset());
+	m_ui->preset->setCurrentIndex(m_presetModel->indexOf(preset));
+}
+
+void InputSettings::renamePreset()
+{
+	const input::Preset *preset = currentPreset();
+	if(preset) {
+		bool ok;
+		QString name = QInputDialog::getText(this, tr("Rename Preset"),
+				tr("Preset name:"), QLineEdit::Normal, preset->name, &ok);
+		input::Preset *mutablePreset = mutableCurrentPreset();
+		if(preset == mutablePreset && ok && !name.isEmpty()) {
+			m_presetModel->rename(*mutablePreset, name);
+		}
+	}
+}
+
+void InputSettings::removePreset()
+{
+	const input::Preset *preset = currentPreset();
+	if(preset) {
+		m_presetModel->remove(*preset);
+	}
+}
+
+void InputSettings::presetDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+{
+	int i = m_ui->preset->currentIndex();
+	if(i >= 0 && i >= topLeft.row() && i <= bottomRight.row()) {
+		const input::Preset *preset = currentPreset();
+		if(preset) {
+			updatePresetMenu();
+		}
+	}
+}
+
+
+void InputSettings::applyPresetToUi(const input::Preset &preset)
+{
+	if(!m_updateInProgress) {
+		m_updateInProgress = true;
+		m_ui->smoothing->setValue(preset.smoothing);
+		m_ui->pressuresrc->setCurrentIndex(preset.pressureMode);
+		m_ui->stackedWidget->setCurrentIndex(m_ui->pressuresrc->currentIndex());
+		m_ui->stylusCurve->setCurve(preset.stylusCurve);
+		m_ui->distanceCurve->setCurve(preset.distanceCurve);
+		m_ui->velocityCurve->setCurve(preset.velocityCurve);
+		m_ui->distance->setValue(preset.distance);
+		m_ui->velocity->setValue(preset.velocity);
+		m_updateInProgress = false;
+		updateSmoothing();
+		updatePressureMapping();
+	}
+}
+
+void InputSettings::updatePresetMenu() const
+{
+	m_removePresetAction->setEnabled(m_presetModel->size() > 1);
+}
+
+void InputSettings::applyUiToPreset(input::Preset &preset) const
+{
+	if(!m_updateInProgress) {
+		m_presetModel->apply(preset, m_ui->smoothing->value(),
+				m_ui->pressuresrc->currentIndex(), m_ui->stylusCurve->curve(),
+				m_ui->distanceCurve->curve(), m_ui->velocityCurve->curve(),
+				m_ui->distance->value(), m_ui->velocity->value());
+	}
 }
 
 }

--- a/src/desktop/docks/inputsettingsdock.h
+++ b/src/desktop/docks/inputsettingsdock.h
@@ -20,8 +20,11 @@
 #define InputSettings_H
 
 #include "canvas/pressure.h"
+#include "inputpresetmodel.h"
 
 #include <QDockWidget>
+#include <QMenu>
+#include <QSettings>
 
 class Ui_InputSettings;
 
@@ -29,26 +32,36 @@ namespace docks {
 
 class InputSettings : public QDockWidget
 {
-	Q_PROPERTY(PressureMapping pressureMapping READ getPressureMapping NOTIFY pressureMappingChanged)
-	Q_PROPERTY(int smoothing READ getSmoothing NOTIFY smoothingChanged)
-
 	Q_OBJECT
 public:
-	explicit InputSettings(QWidget *parent = 0);
+	explicit InputSettings(input::PresetModel *presetModel, QWidget *parent = 0);
 	~InputSettings();
 
-	int getSmoothing() const;
-	PressureMapping getPressureMapping() const;
-
-signals:
-	void smoothingChanged(int value);
-	void pressureMappingChanged(const PressureMapping &mapping);
+	const input::Preset *currentPreset() const;
 
 private slots:
+	void updateSmoothing();
 	void updatePressureMapping();
+	void choosePreset(int index);
+	void addPreset();
+	void renamePreset();
+	void removePreset();
+	void presetDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
 private:
+	input::Preset *mutableCurrentPreset();
+
+	void applyPresetToUi(const input::Preset &preset);
+	void applyUiToPreset(input::Preset &preset) const;
+	void updatePresetMenu() const;
+
 	Ui_InputSettings *m_ui;
+	input::PresetModel *m_presetModel;
+	bool m_updateInProgress;
+	QMenu *m_presetmenu;
+	QAction *m_addPresetAction;
+	QAction *m_renamePresetAction;
+	QAction *m_removePresetAction;
 };
 
 }

--- a/src/desktop/docks/toolsettingsdock.cpp
+++ b/src/desktop/docks/toolsettingsdock.cpp
@@ -17,6 +17,8 @@
    along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "inputpresetmodel.h"
+
 #include "docks/toolsettingsdock.h"
 #include "docks/utils.h"
 
@@ -66,7 +68,7 @@ struct ToolSettings::Private {
 		return pages[currentTool].settings.data();
 	}
 
-	Private(tools::ToolController *ctrl)
+	Private(tools::ToolController *ctrl, input::PresetModel *presetModel)
 		: ctrl(ctrl),
 		  widgetStack(nullptr),
 		  colorDialog(nullptr),
@@ -79,7 +81,7 @@ struct ToolSettings::Private {
 		Q_ASSERT(ctrl);
 
 		// Create tool pages
-		auto brush = QSharedPointer<tools::ToolSettings>(new tools::BrushSettings(ctrl));
+		auto brush = QSharedPointer<tools::ToolSettings>(new tools::BrushSettings(ctrl, presetModel));
 		auto sel = QSharedPointer<tools::ToolSettings>(new tools::SelectionSettings(ctrl));
 
 		pages[tools::Tool::FREEHAND] = {
@@ -160,8 +162,8 @@ struct ToolSettings::Private {
 	}
 };
 
-ToolSettings::ToolSettings(tools::ToolController *ctrl, QWidget *parent)
-	: QDockWidget(parent), d(new Private(ctrl))
+ToolSettings::ToolSettings(tools::ToolController *ctrl, input::PresetModel *presetModel,
+		QWidget *parent) : QDockWidget(parent), d(new Private(ctrl, presetModel))
 {
 	setStyleSheet(defaultDockStylesheet());
 

--- a/src/desktop/docks/toolsettingsdock.h
+++ b/src/desktop/docks/toolsettingsdock.h
@@ -25,6 +25,9 @@
 
 class QStackedWidget;
 
+namespace input {
+	class PresetModel;
+}
 
 namespace tools {
 	class ToolSettings;
@@ -41,7 +44,8 @@ class ToolSettings : public QDockWidget
 {
 Q_OBJECT
 public:
-	ToolSettings(tools::ToolController *ctrl, QWidget *parent=nullptr);
+	ToolSettings(tools::ToolController *ctrl, input::PresetModel *presetModel,
+			QWidget *parent=nullptr);
 	~ToolSettings();
 
 	//! Get the current foreground color

--- a/src/desktop/inputpresetmodel.cpp
+++ b/src/desktop/inputpresetmodel.cpp
@@ -1,0 +1,380 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2014-2020 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "inputpresetmodel.h"
+
+#include <QDebug>
+#include <QUuid>
+
+namespace input {
+const int PresetModel::SMOOTHING_DEFAULT = 5;
+const int PresetModel::DISTANCE_DEFAULT = 105;
+const int PresetModel::VELOCITY_DEFAULT = 55;
+}
+
+namespace {
+
+class PresetCreator {
+public:
+	virtual QString uuid() { return ""; }
+	virtual QString name() { return ""; }
+
+	virtual int smoothing() { return input::PresetModel::SMOOTHING_DEFAULT; }
+	virtual int pressureMode() { return 0; }
+
+	virtual bool hasStylusCurve() { return false; }
+	virtual bool hasDistanceCurve() { return false; }
+	virtual bool hasVelocityCurve() { return false; }
+
+	virtual QString stylusCurve() { return ""; }
+	virtual QString distanceCurve() { return ""; }
+	virtual QString velocityCurve() { return ""; }
+
+	virtual int distance() { return input::PresetModel::DISTANCE_DEFAULT; }
+	virtual int velocity() { return input::PresetModel::VELOCITY_DEFAULT; }
+
+	void create(input::Preset &preset, int i);
+};
+
+class SettingsPresetCreator : public PresetCreator {
+public:
+	explicit SettingsPresetCreator(QSettings &cfg) : PresetCreator{}, m_cfg{cfg} {}
+
+	QString uuid() override { return m_cfg.value("uuid").toString(); }
+	QString name() override { return m_cfg.value("name").toString(); }
+
+	virtual int smoothing() { return m_cfg.value("smoothing", PresetCreator::smoothing()).toInt(); }
+	virtual int pressureMode() { return m_cfg.value("pressuremode", PresetCreator::pressureMode()).toInt(); }
+
+	virtual bool hasStylusCurve() { return m_cfg.contains("pressurecurve"); }
+	virtual bool hasDistanceCurve() { return m_cfg.contains("distancecurve"); }
+	virtual bool hasVelocityCurve() { return m_cfg.contains("velocitycurve"); }
+
+	virtual QString stylusCurve() { return m_cfg.value("pressurecurve").toString(); }
+	virtual QString distanceCurve() { return m_cfg.value("distancecurve").toString(); }
+	virtual QString velocityCurve() { return m_cfg.value("velocitycurve").toString(); }
+
+	virtual int distance() { return m_cfg.value("distance", PresetCreator::distance()).toInt(); }
+	virtual int velocity() { return m_cfg.value("velocity", PresetCreator::velocity()).toInt(); }
+
+private:
+	QSettings &m_cfg;
+};
+
+class PresetCreatorFrom : public PresetCreator {
+public:
+	PresetCreatorFrom(const input::Preset &from) : PresetCreator{}, m_from{from} {}
+
+	virtual int smoothing() { return m_from.smoothing; }
+	virtual int pressureMode() { return m_from.pressureMode; }
+
+	virtual bool hasStylusCurve() { return true; }
+	virtual bool hasDistanceCurve() { return true; }
+	virtual bool hasVelocityCurve() { return true; }
+
+	virtual QString stylusCurve() { return m_from.stylusCurve.toString(); }
+	virtual QString distanceCurve() { return m_from.distanceCurve.toString(); }
+	virtual QString velocityCurve() { return m_from.velocityCurve.toString(); }
+
+	virtual int distance() { return m_from.distance; }
+	virtual int velocity() { return m_from.velocity; }
+
+private:
+	const input::Preset &m_from;
+};
+
+void PresetCreator::create(input::Preset &preset, int i)
+{
+	preset.uuid = uuid();
+	if(preset.uuid.isEmpty()) {
+		preset.uuid = QUuid::createUuid().toString();
+	}
+
+	preset.name = name();
+	if(preset.name.isEmpty()) {
+		preset.name = QString("%1 %2").arg("Preset", QString::number(i + 1));
+	}
+
+	preset.smoothing = smoothing();
+	preset.pressureMode = pressureMode();
+
+	if(hasStylusCurve()) {
+		preset.stylusCurve.fromString(stylusCurve());
+	}
+
+	if(hasDistanceCurve()) {
+		preset.distanceCurve.fromString(distanceCurve());
+	}
+
+	if(hasVelocityCurve()) {
+		preset.velocityCurve.fromString(velocityCurve());
+	}
+
+	preset.distance = distance();
+	preset.velocity = velocity();
+}
+
+}
+
+namespace input {
+
+PressureMapping Preset::getPressureMapping() const
+{
+	PressureMapping pm;
+	switch(pressureMode) {
+	case 0:
+		pm.mode = PressureMapping::STYLUS;
+		pm.curve = stylusCurve;
+		pm.param = 0;
+		break;
+	case 1:
+		pm.mode = PressureMapping::DISTANCE;
+		pm.curve = distanceCurve;
+		pm.param = distance;
+		break;
+	case 2:
+		pm.mode = PressureMapping::VELOCITY;
+		pm.curve = velocityCurve;
+		pm.param = velocity;
+		break;
+	}
+	return pm;
+}
+
+PresetModel::PresetModel(QObject *parent) :
+	QAbstractListModel{parent},
+	m_presets{}
+{
+	restoreSettings();
+}
+
+PresetModel::~PresetModel()
+{
+	saveSettings();
+}
+
+int PresetModel::rowCount(const QModelIndex &parent) const
+{
+	return parent.isValid() ? 0 : m_presets.size();
+}
+
+QVariant PresetModel::data(const QModelIndex &index, int role) const
+{
+	if(index.isValid() && index.row() >= 0 && index.row() < m_presets.size() && role == Qt::DisplayRole) {
+		return m_presets.at(index.row()).name;
+	}
+	return QVariant();
+}
+
+
+Preset *PresetModel::operator[](int i)
+{
+	return i >= 0 && i < m_presets.size() ? &m_presets[i] : nullptr;
+}
+
+const Preset *PresetModel::at(int i) const
+{
+	return i >= 0 && i < m_presets.size() ? &m_presets.at(i) : nullptr;
+}
+
+int PresetModel::indexOf(const Preset &preset) const
+{
+	int size = m_presets.size();
+	for(int i = 0; i < size; ++i) {
+		if(&preset == &m_presets.at(i)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+int PresetModel::size() const
+{
+	return m_presets.size();
+}
+
+
+int PresetModel::searchIndexByUuid(const QString &uuid) const
+{
+	int size = m_presets.size();
+	for(int i = 0; i < size; ++i) {
+		if(m_presets.at(i).uuid == uuid) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+const Preset *PresetModel::searchPresetByUuid(const QString &uuid) const
+{
+	int i = searchIndexByUuid(uuid);
+	return i >= 0 ? &m_presets.at(i) : nullptr;
+}
+
+
+Preset &PresetModel::add(const Preset *from)
+{
+	int size = m_presets.size();
+	beginInsertRows(QModelIndex{}, size, size);
+	m_presets.resize(size + 1);
+	Preset &preset = m_presets[size];
+	if(from) {
+		createPresetFrom(preset, size, *from);
+	} else {
+		createBlankPreset(preset, size);
+	}
+	endInsertRows();
+	return preset;
+}
+
+void PresetModel::createPresetFrom(Preset &preset, int i, const Preset &from)
+{
+	PresetCreatorFrom(from).create(preset, i);
+}
+
+void PresetModel::remove(const Preset &preset)
+{
+	int indexToRemove = indexOf(preset);
+	if(indexToRemove >= 0 && size() > 1) {
+		QString uuid = preset.uuid;
+		beginRemoveRows(QModelIndex{}, indexToRemove, indexToRemove);
+		m_presets.removeAt(indexToRemove);
+		endRemoveRows();
+		emit presetRemoved(uuid);
+	}
+}
+
+void PresetModel::rename(Preset &preset, const QString &name)
+{
+	int indexToRename = indexOf(preset);
+	if(indexToRename >= 0) {
+		preset.name = name;
+		emitChangeAt(indexToRename);
+	}
+}
+
+void PresetModel::emitChangeAt(int i)
+{
+	if(i >= 0 && i < m_presets.size()) {
+		QModelIndex qmi = index(i);
+		emit dataChanged(qmi, qmi);
+	}
+}
+
+void PresetModel::apply(Preset &preset, int smoothing, int pressureMode,
+		const KisCubicCurve &stylusCurve, const KisCubicCurve &distanceCurve,
+		const KisCubicCurve &velocityCurve, int distance, int velocity)
+{
+	preset.smoothing = smoothing;
+	preset.pressureMode = pressureMode;
+	preset.stylusCurve = stylusCurve;
+	preset.distanceCurve = distanceCurve;
+	preset.velocityCurve = velocityCurve;
+	preset.distance = distance;
+	preset.velocity = velocity;
+	emit presetChanged(preset);
+}
+
+
+void PresetModel::restoreSettings()
+{
+	beginResetModel();
+	m_presets.clear();
+
+	QSettings cfg;
+	restorePresetsSettings(cfg);
+
+	if (m_presets.isEmpty()) {
+		restoreLegacySettings(cfg);
+	}
+
+	endResetModel();
+}
+
+void PresetModel::restorePresetsSettings(QSettings &cfg)
+{
+	int size = cfg.beginReadArray("inputpresets");
+	m_presets.resize(size);
+	for(int i = 0; i < size; ++i) {
+		cfg.setArrayIndex(i);
+		restorePreset(cfg, m_presets[i], i);
+	}
+	cfg.endArray();
+}
+
+void PresetModel::restoreLegacySettings(QSettings &cfg)
+{
+	m_presets.resize(1);
+	cfg.beginGroup("input");
+	restorePreset(cfg, m_presets[0], 0);
+	cfg.endGroup();
+}
+
+void PresetModel::restorePreset(QSettings &cfg, Preset &preset, int i)
+{
+	SettingsPresetCreator{cfg}.create(preset, i);
+}
+
+Preset &PresetModel::firstPresetOrCreateBlank()
+{
+	if(m_presets.isEmpty()) {
+		m_presets.resize(1);
+		createBlankPreset(m_presets[0], 0);
+	}
+	return m_presets[0];
+}
+
+void PresetModel::createBlankPreset(Preset &preset, int i)
+{
+	PresetCreator{}.create(preset, i);
+}
+
+
+void PresetModel::saveSettings()
+{
+	QSettings cfg;
+
+	cfg.beginGroup("input");
+	savePreset(cfg, firstPresetOrCreateBlank(), true);
+	cfg.endGroup();
+
+	int size = m_presets.size();
+	cfg.beginWriteArray("inputpresets", size);
+	for(int i = 0; i < size; ++i) {
+		cfg.setArrayIndex(i);
+		savePreset(cfg, m_presets.at(i), false);
+	}
+	cfg.endArray();
+}
+
+void PresetModel::savePreset(QSettings &cfg, const Preset &preset, bool legacy)
+{
+	if(!legacy) {
+		cfg.setValue("uuid", preset.uuid);
+		cfg.setValue("name", preset.name);
+	}
+	cfg.setValue("smoothing", preset.smoothing);
+	cfg.setValue("pressuremode", preset.pressureMode);
+	cfg.setValue("pressurecurve", preset.stylusCurve.toString());
+	cfg.setValue("distancecurve", preset.distanceCurve.toString());
+	cfg.setValue("velocitycurve", preset.velocityCurve.toString());
+	cfg.setValue("distance", preset.distance);
+	cfg.setValue("velocity", preset.velocity);
+}
+
+}

--- a/src/desktop/inputpresetmodel.h
+++ b/src/desktop/inputpresetmodel.h
@@ -1,0 +1,107 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2014-2020 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef PresetModel_H
+#define PresetModel_H
+
+#include "canvas/pressure.h"
+
+#include <QAbstractListModel>
+#include <QSettings>
+#include <QVector>
+
+namespace input {
+
+struct Preset {
+	QString uuid;
+	QString name;
+	int smoothing;
+	int pressureMode;
+	KisCubicCurve stylusCurve;
+	KisCubicCurve distanceCurve;
+	KisCubicCurve velocityCurve;
+	int distance;
+	int velocity;
+
+	PressureMapping getPressureMapping() const;
+};
+
+}
+
+Q_DECLARE_TYPEINFO(input::Preset, Q_MOVABLE_TYPE);
+
+namespace input {
+
+class PresetModel : public QAbstractListModel {
+	Q_OBJECT
+public:
+	explicit PresetModel(QObject *parent = nullptr);
+	~PresetModel();
+
+	PresetModel(const PresetModel &) = delete;
+	PresetModel &operator=(const PresetModel &) = delete;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+	Preset *operator[](int i);
+	const Preset *at(int i) const;
+	int indexOf(const Preset &preset) const;
+	int size() const;
+
+	int searchIndexByUuid(const QString &uuid) const;
+	const Preset *searchPresetByUuid(const QString &uuid) const;
+
+	Preset &add(const Preset *from = nullptr);
+	void remove(const Preset &preset);
+	void rename(Preset &preset, const QString &name);
+	void apply(Preset &preset, int smoothing, int pressureMode,
+			const KisCubicCurve &stylusCurve, const KisCubicCurve &distanceCurve,
+			const KisCubicCurve &velocityCurve, int distance, int velocity);
+
+	static const int SMOOTHING_DEFAULT;
+	static const int DISTANCE_DEFAULT;
+	static const int VELOCITY_DEFAULT;
+
+signals:
+	void presetRemoved(const QString &uuid);
+	void presetChanged(const Preset &preset);
+
+private:
+	void restoreSettings();
+	void saveSettings();
+
+	void createPresetFrom(Preset &preset, int i, const Preset &from);
+	void emitChangeAt(int i);
+
+	void restorePresetsSettings(QSettings &cfg);
+	void restoreLegacySettings(QSettings &cfg);
+	void restorePreset(QSettings &cfg, Preset &preset, int i);
+	Preset &firstPresetOrCreateBlank();
+	void createBlankPreset(Preset &preset, int i);
+
+	void savePreset(QSettings &cfg, const Preset &preset, bool legacy);
+
+	QVector<Preset> m_presets;
+};
+
+}
+
+Q_DECLARE_METATYPE(input::Preset)
+
+#endif

--- a/src/desktop/mainwindow.h
+++ b/src/desktop/mainwindow.h
@@ -68,6 +68,10 @@ namespace canvas {
 	class SessionLoader;
 }
 
+namespace input {
+	class PresetModel;
+}
+
 namespace net {
 	class Client;
 	class LoginHandler;
@@ -213,6 +217,7 @@ private:
 	void setupActions();
 
 	QSplitter *m_splitter;
+	input::PresetModel *m_presetModel;
 
 	docks::ToolSettings *m_dockToolSettings;
 	docks::BrushPalette *m_dockBrushPalette;

--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -22,6 +22,7 @@
 #include "tools/toolproperties.h"
 #include "brushes/brush.h"
 
+#include "inputpresetmodel.h"
 #include "ui_brushdock.h"
 
 #include <QKeyEvent>
@@ -46,11 +47,14 @@ namespace {
 		// For remembering previuous selection when switching between normal/erase mode
 		paintcore::BlendMode::Mode normalMode = paintcore::BlendMode::MODE_NORMAL;
 		paintcore::BlendMode::Mode eraserMode = paintcore::BlendMode::MODE_ERASE;
+
+		QString inputPresetUuid;
 	};
 }
 
 struct BrushSettings::Private {
 	Ui_BrushDock ui;
+	input::PresetModel *presetModel;
 
 	QStandardItemModel *blendModes, *eraseModes;
 
@@ -73,7 +77,8 @@ struct BrushSettings::Private {
 		return toolSlots[current];
 	}
 
-	Private(BrushSettings *b)
+	Private(BrushSettings *b, input::PresetModel *presetModel) :
+		presetModel(presetModel)
 	{
 		blendModes = new QStandardItemModel(0, 1, b);
 		for(const auto &bm : paintcore::getBlendModeNames(paintcore::BlendMode::BrushMode)) {
@@ -105,10 +110,28 @@ struct BrushSettings::Private {
 		default: qFatal("brushSlotButton(%d): no such button", i);
 		}
 	}
+
+	void updateInputPresetUuid(ToolSlot &tool)
+	{
+		const input::Preset *preset = presetFor(tool);
+		if(!preset && presetModel->size() >= 1) {
+			tool.inputPresetUuid = presetModel->at(0)->uuid;
+		}
+	}
+
+	const input::Preset *currentPreset()
+	{
+		return presetFor(currentTool());
+	}
+
+	const input::Preset *presetFor(const ToolSlot &tool)
+	{
+		return presetModel->searchPresetByUuid(tool.inputPresetUuid);
+	}
 };
 
-BrushSettings::BrushSettings(ToolController *ctrl, QObject *parent)
-	: ToolSettings(ctrl, parent), d(new Private(this))
+BrushSettings::BrushSettings(ToolController *ctrl, input::PresetModel *presetModel, QObject *parent)
+	: ToolSettings(ctrl, parent), d(new Private(this, presetModel))
 {
 }
 
@@ -121,6 +144,7 @@ QWidget *BrushSettings::createUiWidget(QWidget *parent)
 {
 	QWidget *widget = new QWidget(parent);
 	d->ui.setupUi(widget);
+	d->ui.inputPreset->setModel(d->presetModel);
 
 	// Outside communication
 	connect(d->ui.brushsizeBox, SIGNAL(valueChanged(int)), parent, SIGNAL(sizeChanged(int)));
@@ -153,6 +177,10 @@ QWidget *BrushSettings::createUiWidget(QWidget *parent)
 	connect(d->ui.brushspacingBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &BrushSettings::updateFromUi);
 	connect(d->ui.modeIncremental, &QToolButton::clicked, this, &BrushSettings::updateFromUi);
 	connect(d->ui.modeColorpick, &QToolButton::clicked, this, &BrushSettings::updateFromUi);
+
+	connect(d->ui.inputPreset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &BrushSettings::chooseInputPreset);
+	connect(d->presetModel, &input::PresetModel::presetRemoved, this, &BrushSettings::inputPresetRemoved);
+	connect(d->presetModel, &input::PresetModel::presetChanged, this, &BrushSettings::inputPresetChanged);
 
 	// Brush slot buttons
 	for(int i=0;i<BRUSH_COUNT;++i) {
@@ -206,6 +234,8 @@ void BrushSettings::selectBrushSlot(int i)
 
 	if(!d->shareBrushSlotColor)
 		emit colorChanged(d->currentBrush().color());
+
+	d->updateInputPresetUuid(d->currentTool());
 
 	updateUi();
 
@@ -342,6 +372,8 @@ void BrushSettings::updateUi()
 	d->ui.modeIncremental->setChecked(brush.incremental());
 	d->ui.modeColorpick->setChecked(brush.isColorPickMode());
 
+	updateInputPresetIndex(tool.inputPresetUuid);
+
 	d->updateInProgress = false;
 	d->ui.preview->setBrush(d->currentBrush());
 	pushSettings();
@@ -381,6 +413,8 @@ void BrushSettings::updateFromUi()
 	brush.setColorPickMode(d->ui.modeColorpick->isChecked());
 	brush.setBlendingMode(paintcore::BlendMode::Mode(d->ui.blendmode->currentData(Qt::UserRole).toInt()));
 
+	chooseInputPreset(d->ui.inputPreset->currentIndex());
+
 	d->ui.preview->setBrush(brush);
 
 	d->ui.modeIncremental->setEnabled(brush.smudge1() == 0.0);
@@ -391,6 +425,66 @@ void BrushSettings::updateFromUi()
 void BrushSettings::pushSettings()
 {
 	controller()->setActiveBrush(d->ui.preview->brush());
+}
+
+void BrushSettings::chooseInputPreset(int index)
+{
+	ToolSlot &tool = d->currentTool();
+	const input::Preset *preset = d->presetModel->at(index);
+	if(preset && tool.inputPresetUuid != preset->uuid) {
+		tool.inputPresetUuid = preset->uuid;
+	}
+	emitPresetChanges(preset);
+}
+
+void BrushSettings::inputPresetRemoved(const QString &uuid)
+{
+	int current = d->current;
+	for(int i = 0; i < BRUSH_COUNT; ++i) {
+		ToolSlot &tool = d->toolSlots[i];
+		if(tool.inputPresetUuid == uuid) {
+			d->updateInputPresetUuid(tool);
+			if(i == current) {
+				updateInputPresetIndex(tool.inputPresetUuid);
+				emitPresetChanges(d->presetFor(tool));
+			}
+		}
+	}
+}
+
+void BrushSettings::updateInputPresetIndex(const QString &uuid)
+{
+	int i = d->presetModel->searchIndexByUuid(uuid);
+	if(i >= 0) {
+		d->ui.inputPreset->setCurrentIndex(i);
+	}
+}
+
+void BrushSettings::inputPresetChanged(const input::Preset &preset)
+{
+	if(d->currentTool().inputPresetUuid == preset.uuid) {
+		emitPresetChanges(&preset);
+	}
+}
+
+void BrushSettings::emitPresetChanges(const input::Preset *preset)
+{
+	if(preset) {
+		emit smoothingChanged(preset->smoothing);
+		emit pressureMappingChanged(preset->getPressureMapping());
+	}
+}
+
+int BrushSettings::getSmoothing() const
+{
+	const input::Preset *preset = d->currentPreset();
+	return preset ? preset->smoothing : input::PresetModel::SMOOTHING_DEFAULT;
+}
+
+PressureMapping BrushSettings::getPressureMapping() const
+{
+	const input::Preset *preset = d->currentPreset();
+	return preset ? preset->getPressureMapping() : PressureMapping{};
 }
 
 namespace toolprop {
@@ -413,7 +507,8 @@ ToolProperties BrushSettings::saveToolSettings()
 		b["_slot"] = QJsonObject {
 			{"normalMode", tool.normalMode},
 			{"eraserMode", tool.eraserMode},
-			{"color", tool.brush.color().name()}
+			{"color", tool.brush.color().name()},
+			{"inputPresetUuid", tool.inputPresetUuid}
 		};
 
 		cfg.setValue(
@@ -447,6 +542,8 @@ void BrushSettings::restoreToolSettings(const ToolProperties &cfg)
 		tool.brush.setColor(color.isValid() ? color : Qt::black);
 		tool.normalMode = paintcore::BlendMode::Mode(s["normalMode"].toInt());
 		tool.eraserMode = paintcore::BlendMode::Mode(s["eraserMode"].toInt());
+		tool.inputPresetUuid = s["inputPresetUuid"].toString();
+		d->updateInputPresetUuid(tool);
 
 		if(!d->shareBrushSlotColor)
 			d->brushSlotButton(i)->setColorSwatch(tool.brush.color());

--- a/src/desktop/toolwidgets/brushsettings.h
+++ b/src/desktop/toolwidgets/brushsettings.h
@@ -19,12 +19,18 @@
 #ifndef TOOLSETTINGS_BRUSHES_H
 #define TOOLSETTINGS_BRUSHES_H
 
+#include "canvas/pressure.h"
 #include "toolsettings.h"
 
 class QAction;
 
 namespace brushes {
 	class ClassicBrush;
+}
+
+namespace input {
+	class Preset;
+	class PresetModel;
 }
 
 namespace tools {
@@ -38,7 +44,7 @@ class BrushSettings : public ToolSettings {
 	Q_OBJECT
 	friend class AdvancedBrushSettings;
 public:
-	BrushSettings(ToolController *ctrl, QObject *parent=nullptr);
+	BrushSettings(ToolController *ctrl, input::PresetModel *presetModel, QObject *parent=nullptr);
 	~BrushSettings();
 
 	QString toolType() const override { return QStringLiteral("brush"); }
@@ -63,6 +69,9 @@ public:
 
 	void setShareBrushSlotColor(bool sameColor);
 
+	int getSmoothing() const;
+	PressureMapping getPressureMapping() const;
+
 public slots:
 	void selectBrushSlot(int i);
 	void selectEraserSlot(bool eraser);
@@ -72,6 +81,8 @@ signals:
 	void colorChanged(const QColor &color);
 	void eraseModeChanged(bool erase);
 	void subpixelModeChanged(bool subpixel, bool square);
+	void smoothingChanged(int smoothing);
+	void pressureMappingChanged(const PressureMapping &pressureMapping);
 
 protected:
 	QWidget *createUiWidget(QWidget *parent) override;
@@ -81,8 +92,14 @@ private slots:
 	void setEraserMode(bool erase);
 	void updateUi();
 	void updateFromUi();
+	void chooseInputPreset(int index);
+	void inputPresetRemoved(const QString &uuid);
+	void inputPresetChanged(const input::Preset &preset);
 
 private:
+	void updateInputPresetIndex(const QString &uuid);
+	void emitPresetChanges(const input::Preset *preset);
+
 	struct Private;
 	Private *d;
 };

--- a/src/desktop/ui/brushdock.ui
+++ b/src/desktop/ui/brushdock.ui
@@ -600,6 +600,16 @@
        </property>
       </widget>
      </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Input:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="3">
+      <widget class="QComboBox" name="inputPreset"/>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/desktop/ui/inputcfg.ui
+++ b/src/desktop/ui/inputcfg.ui
@@ -38,13 +38,20 @@
       <number>5</number>
      </property>
      <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Preset:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Smoothing:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="QSlider" name="smoothing">
        <property name="maximum">
         <number>10</number>
@@ -60,14 +67,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Pressure:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QComboBox" name="pressuresrc">
        <item>
         <property name="text">
@@ -85,6 +92,59 @@
         </property>
        </item>
       </widget>
+     </item>
+     <item row="0" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="QComboBox" name="preset">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+         <property name="insertPolicy">
+          <enum>QComboBox::NoInsert</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>4</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="widgets::GroupedToolButton" name="presetButton">
+         <property name="toolTip">
+          <string>Preset options</string>
+         </property>
+         <property name="icon">
+          <iconset theme="application-menu">
+           <normaloff>theme:application-menu.svg</normaloff>theme:application-menu.svg</iconset>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -243,6 +303,11 @@
    <extends>QWidget</extends>
    <header>widgets/kis_curve_widget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>widgets::GroupedToolButton</class>
+   <extends>QToolButton</extends>
+   <header>widgets/groupedtoolbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
The input tab now allows specifying multiple different smoothing and
pressure mapping configurations. Every brush slot lets you pick which of
these configurations you want to use for it.

This lets you, for example, create a "sketch" configuration with little
smoothing assigned to brush 1 and a "line" configuration with lots of
smoothing for brush 2.

Resolves #915.

Showing it off:

https://user-images.githubusercontent.com/13625824/103174749-d4db3f80-4864-11eb-87d5-2b4ffa7f9253.mp4

