### PR TITLE
Add perspective transform (distort/free transform/free deform)

### DIFF
--- a/src/desktop/scene/arrows_data.h
+++ b/src/desktop/scene/arrows_data.h
@@ -41,6 +41,30 @@ static const QPointF
 ,verticalSkew[] {
 	{2,5}, {8,0}, {8,5}, {2,10}
 }
+,distortTopLeft[] {
+	{0,0}, {5,0}, {5,5}, {0,5}
+}
+,distortTop[] {
+	{3,0}, {8,0}, {8,5}, {3,5}
+}
+,distortTopRight[] {
+	{5,0}, {10,0}, {10,5}, {5,5}
+}
+,distortRight[] {
+	{5,3}, {10,3}, {10,8}, {5,8}
+}
+,distortBottomRight[] {
+	{5,5}, {10,5}, {10,10}, {5,10}
+}
+,distortBottom[] {
+	{3,5}, {8,5}, {8,10}, {3,10}
+}
+,distortBottomLeft[] {
+	{0,5}, {5,5}, {5,10}, {0,10}
+}
+,distortLeft[] {
+	{0,3}, {5,3}, {5,8}, {0,8}
+}
 ;
 
 }

--- a/src/desktop/scene/selectionitem.cpp
+++ b/src/desktop/scene/selectionitem.cpp
@@ -62,65 +62,89 @@ static inline void drawPolygon(QPainter *painter, const QPolygonF &polygon, bool
 		painter->drawPolyline(polygon);
 }
 
-static void drawHandle(QPainter *painter, const QPointF &point, qreal size, canvas::Selection::Handle handle, bool scaleMode)
+static const QPointF *getScaleArrow(canvas::Selection::Handle handle, unsigned int &outPlen)
 {
-	const QPointF *arrow;
-	unsigned int plen=0;
-
-	if(scaleMode) {
-		switch(handle) {
-			case canvas::Selection::Handle::TopLeft:
-			case canvas::Selection::Handle::BottomRight:
-				arrow = arrows::diag1; plen = sizeof(arrows::diag1);
-				break;
-			case canvas::Selection::Handle::TopRight:
-			case canvas::Selection::Handle::BottomLeft:
-				arrow = arrows::diag2; plen = sizeof(arrows::diag2);
-				break;
-			case canvas::Selection::Handle::Top:
-			case canvas::Selection::Handle::Bottom:
-				arrow = arrows::vertical; plen = sizeof(arrows::vertical);
-				break;
-			case canvas::Selection::Handle::Left:
-			case canvas::Selection::Handle::Right:
-				arrow = arrows::horizontal; plen = sizeof(arrows::horizontal);
-				break;
-			default: return;
-		}
-	} else {
-		switch(handle) {
-			case canvas::Selection::Handle::TopLeft:
-				arrow = arrows::rotate1; plen = sizeof(arrows::rotate1);
-				break;
-			case canvas::Selection::Handle::TopRight:
-				arrow = arrows::rotate2; plen = sizeof(arrows::rotate2);
-				break;
-			case canvas::Selection::Handle::BottomRight:
-				arrow = arrows::rotate3; plen = sizeof(arrows::rotate3);
-				break;
-			case canvas::Selection::Handle::BottomLeft:
-				arrow = arrows::rotate4; plen = sizeof(arrows::rotate4);
-				break;
-			case canvas::Selection::Handle::Left:
-			case canvas::Selection::Handle::Right:
-				arrow = arrows::verticalSkew; plen = sizeof(arrows::verticalSkew);
-				break;
-			case canvas::Selection::Handle::Top:
-			case canvas::Selection::Handle::Bottom:
-				arrow = arrows::horizontalSkew; plen = sizeof(arrows::horizontalSkew);
-				break;
-			default: return;
-		}
+	switch(handle) {
+	case canvas::Selection::Handle::TopLeft:
+	case canvas::Selection::Handle::BottomRight:
+		outPlen = sizeof(arrows::diag1);
+		return arrows::diag1;
+	case canvas::Selection::Handle::TopRight:
+	case canvas::Selection::Handle::BottomLeft:
+		outPlen = sizeof(arrows::diag2);
+		return arrows::diag2;
+	case canvas::Selection::Handle::Top:
+	case canvas::Selection::Handle::Bottom:
+		outPlen = sizeof(arrows::vertical);
+		return arrows::vertical;
+	case canvas::Selection::Handle::Left:
+	case canvas::Selection::Handle::Right:
+		outPlen = sizeof(arrows::horizontal);
+		return arrows::horizontal;
+	default:
+		return nullptr;
 	}
+}
 
-	const QPointF offset = point - QPointF(size/2, size/2);
+static const QPointF *getRotationArrow(canvas::Selection::Handle handle, unsigned int &outPlen)
+{
+	switch(handle) {
+	case canvas::Selection::Handle::TopLeft:
+		outPlen = sizeof(arrows::rotate1);
+		return arrows::rotate1;
+	case canvas::Selection::Handle::TopRight:
+		outPlen = sizeof(arrows::rotate2);
+		return arrows::rotate2;
+	case canvas::Selection::Handle::BottomRight:
+		outPlen = sizeof(arrows::rotate3);
+		return arrows::rotate3;
+	case canvas::Selection::Handle::BottomLeft:
+		outPlen = sizeof(arrows::rotate4);
+		return arrows::rotate4;
+	case canvas::Selection::Handle::Left:
+	case canvas::Selection::Handle::Right:
+		outPlen = sizeof(arrows::verticalSkew);
+		return arrows::verticalSkew;
+	case canvas::Selection::Handle::Top:
+	case canvas::Selection::Handle::Bottom:
+		outPlen = sizeof(arrows::horizontalSkew);
+		return arrows::horizontalSkew;
+	default:
+		return nullptr;
+	}
+}
 
-	QPointF polygon[12];
-	Q_ASSERT(plen <= sizeof(polygon));
-	for(unsigned int i=0;i<plen/sizeof(*polygon);++i)
-		polygon[i] = offset + arrow[i] / 10 * size;
+typedef const QPointF *(*GetArrowFunction)(canvas::Selection::Handle handle, unsigned int &outPlen);
 
-	painter->drawPolygon(polygon, plen/sizeof(*polygon));
+static GetArrowFunction mapModeToGetArrowFunction(canvas::Selection::AdjustmentMode mode)
+{
+	switch(mode) {
+	case canvas::Selection::AdjustmentMode::Scale:
+		return getScaleArrow;
+	case canvas::Selection::AdjustmentMode::Rotate:
+		return getRotationArrow;
+	default:
+		qWarning("mapModeToGetArrowFunction: unknown mode");
+		return nullptr;
+	}
+}
+
+static void drawHandle(QPainter *painter, const QPointF &point, qreal size,
+		canvas::Selection::Handle handle, GetArrowFunction getArrow)
+{
+	unsigned int plen;
+	const QPointF *arrow = getArrow(handle, plen);
+
+	if(arrow) {
+		const QPointF offset = point - QPointF(size/2, size/2);
+
+		QPointF polygon[12];
+		Q_ASSERT(plen <= sizeof(polygon));
+		for(unsigned int i=0;i<plen/sizeof(*polygon);++i)
+			polygon[i] = offset + arrow[i] / 10 * size;
+
+		painter->drawPolygon(polygon, plen/sizeof(*polygon));
+	}
 }
 
 void SelectionItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt, QWidget *)
@@ -170,26 +194,24 @@ void SelectionItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
 	drawPolygon(painter, m_shape, drawClosed);
 
 	// Draw resizing handles when initial drawing is finished
-	if(m_selection->isClosed()) {
-		const QRect rect = m_selection->boundingRect();
-
+	GetArrowFunction getArrow;
+	if(m_selection->isClosed() && (getArrow = mapModeToGetArrowFunction(m_selection->adjustmentMode()))) {
 		pen.setStyle(Qt::SolidLine);
 		painter->setPen(pen);
 		painter->setBrush(Qt::black);
 
-		const qreal  s = m_selection->handleSize() / opt->levelOfDetailFromTransform(painter->transform());
-		const bool am = m_selection->adjustmentMode() == canvas::Selection::AdjustmentMode::Scale;
+		const QRect rect = m_selection->boundingRect();
+		const qreal s = m_selection->handleSize() / opt->levelOfDetailFromTransform(painter->transform());
+		drawHandle(painter, rect.topLeft(), s, canvas::Selection::Handle::TopLeft, getArrow);
+		drawHandle(painter, rect.topLeft() + QPointF(rect.width()/2, 0), s, canvas::Selection::Handle::Top, getArrow);
+		drawHandle(painter, rect.topRight(), s, canvas::Selection::Handle::TopRight, getArrow);
 
-		drawHandle(painter, rect.topLeft(), s, canvas::Selection::Handle::TopLeft, am);
-		drawHandle(painter, rect.topLeft() + QPointF(rect.width()/2, 0), s, canvas::Selection::Handle::Top, am);
-		drawHandle(painter, rect.topRight(), s, canvas::Selection::Handle::TopRight, am);
+		drawHandle(painter, rect.topLeft() + QPointF(0, rect.height()/2), s, canvas::Selection::Handle::Left, getArrow);
+		drawHandle(painter, rect.topRight() + QPointF(0, rect.height()/2), s, canvas::Selection::Handle::Right, getArrow);
 
-		drawHandle(painter, rect.topLeft() + QPointF(0, rect.height()/2), s, canvas::Selection::Handle::Left, am);
-		drawHandle(painter, rect.topRight() + QPointF(0, rect.height()/2), s, canvas::Selection::Handle::Right, am);
-
-		drawHandle(painter, rect.bottomLeft(), s, canvas::Selection::Handle::BottomLeft, am);
-		drawHandle(painter, rect.bottomLeft() + QPointF(rect.width()/2, 0), s, canvas::Selection::Handle::Bottom, am);
-		drawHandle(painter, rect.bottomRight(), s, canvas::Selection::Handle::BottomRight, am);
+		drawHandle(painter, rect.bottomLeft(), s, canvas::Selection::Handle::BottomLeft, getArrow);
+		drawHandle(painter, rect.bottomLeft() + QPointF(rect.width()/2, 0), s, canvas::Selection::Handle::Bottom, getArrow);
+		drawHandle(painter, rect.bottomRight(), s, canvas::Selection::Handle::BottomRight, getArrow);
 	}
 }
 

--- a/src/desktop/scene/selectionitem.cpp
+++ b/src/desktop/scene/selectionitem.cpp
@@ -114,6 +114,38 @@ static const QPointF *getRotationArrow(canvas::Selection::Handle handle, unsigne
 	}
 }
 
+static const QPointF *getDistortArrow(canvas::Selection::Handle handle, unsigned int &outPlen)
+{
+	switch(handle) {
+	case canvas::Selection::Handle::TopLeft:
+		outPlen = sizeof(arrows::distortTopLeft);
+		return arrows::distortTopLeft;
+	case canvas::Selection::Handle::Top:
+		outPlen = sizeof(arrows::distortTop);
+		return arrows::distortTop;
+	case canvas::Selection::Handle::TopRight:
+		outPlen = sizeof(arrows::distortTopRight);
+		return arrows::distortTopRight;
+	case canvas::Selection::Handle::Right:
+		outPlen = sizeof(arrows::distortRight);
+		return arrows::distortRight;
+	case canvas::Selection::Handle::BottomRight:
+		outPlen = sizeof(arrows::distortBottomRight);
+		return arrows::distortBottomRight;
+	case canvas::Selection::Handle::Bottom:
+		outPlen = sizeof(arrows::distortBottom);
+		return arrows::distortBottom;
+	case canvas::Selection::Handle::BottomLeft:
+		outPlen = sizeof(arrows::distortBottomLeft);
+		return arrows::distortBottomLeft;
+	case canvas::Selection::Handle::Left:
+		outPlen = sizeof(arrows::distortLeft);
+		return arrows::distortLeft;
+	default:
+		return nullptr;
+	}
+}
+
 typedef const QPointF *(*GetArrowFunction)(canvas::Selection::Handle handle, unsigned int &outPlen);
 
 static GetArrowFunction mapModeToGetArrowFunction(canvas::Selection::AdjustmentMode mode)
@@ -123,6 +155,8 @@ static GetArrowFunction mapModeToGetArrowFunction(canvas::Selection::AdjustmentM
 		return getScaleArrow;
 	case canvas::Selection::AdjustmentMode::Rotate:
 		return getRotationArrow;
+	case canvas::Selection::AdjustmentMode::Distort:
+		return getDistortArrow;
 	default:
 		qWarning("mapModeToGetArrowFunction: unknown mode");
 		return nullptr;

--- a/src/desktop/toolwidgets/selectionsettings.cpp
+++ b/src/desktop/toolwidgets/selectionsettings.cpp
@@ -54,6 +54,7 @@ QWidget *SelectionSettings::createUiWidget(QWidget *parent)
 	connect(m_ui->resetsize, SIGNAL(clicked()), this, SLOT(resetSize()));
 	connect(m_ui->scale, SIGNAL(clicked()), this, SLOT(scale()));
 	connect(m_ui->rotateShear, SIGNAL(clicked()), this, SLOT(rotateShear()));
+	connect(m_ui->distort, SIGNAL(clicked()), this, SLOT(distort()));
 	connect(controller(), &ToolController::modelChanged, this, &SelectionSettings::modelChanged);
 
 	setControlsEnabled(false);
@@ -130,6 +131,11 @@ void SelectionSettings::rotateShear()
 	updateSelectionMode(canvas::Selection::AdjustmentMode::Rotate);
 }
 
+void SelectionSettings::distort()
+{
+	updateSelectionMode(canvas::Selection::AdjustmentMode::Distort);
+}
+
 void SelectionSettings::updateSelectionMode(canvas::Selection::AdjustmentMode mode)
 {
 	if(!controller()->model())
@@ -181,6 +187,7 @@ void SelectionSettings::setControlsEnabled(bool enabled)
 	m_ui->resetsize->setEnabled(enabled);
 	m_ui->scale->setEnabled(enabled);
 	m_ui->rotateShear->setEnabled(enabled);
+	m_ui->distort->setEnabled(enabled);
 	if(!enabled) {
 		m_ui->scale->setChecked(true);
 	}
@@ -188,10 +195,19 @@ void SelectionSettings::setControlsEnabled(bool enabled)
 
 void SelectionSettings::selectionAdjustmentModeChanged(canvas::Selection::AdjustmentMode mode)
 {
-	if(mode == canvas::Selection::AdjustmentMode::Scale) {
+	switch(mode) {
+	case canvas::Selection::AdjustmentMode::Scale:
 		m_ui->scale->setChecked(true);
-	} else {
+		break;
+	case canvas::Selection::AdjustmentMode::Rotate:
 		m_ui->rotateShear->setChecked(true);
+		break;
+	case canvas::Selection::AdjustmentMode::Distort:
+		m_ui->distort->setChecked(true);
+		break;
+	default:
+		qWarning("SelectionSettings::selectionAdjustmentModeChanged: unknown adjustment mode");
+		break;
 	}
 }
 

--- a/src/desktop/toolwidgets/selectionsettings.cpp
+++ b/src/desktop/toolwidgets/selectionsettings.cpp
@@ -52,6 +52,11 @@ QWidget *SelectionSettings::createUiWidget(QWidget *parent)
 	connect(m_ui->mirror, SIGNAL(clicked()), this, SLOT(mirrorSelection()));
 	connect(m_ui->fittoscreen, SIGNAL(clicked()), this, SLOT(fitToScreen()));
 	connect(m_ui->resetsize, SIGNAL(clicked()), this, SLOT(resetSize()));
+	connect(m_ui->scale, SIGNAL(clicked()), this, SLOT(scale()));
+	connect(m_ui->rotateShear, SIGNAL(clicked()), this, SLOT(rotateShear()));
+	connect(controller(), &ToolController::modelChanged, this, &SelectionSettings::modelChanged);
+
+	setControlsEnabled(false);
 
 	return uiwidget;
 }
@@ -115,6 +120,49 @@ void SelectionSettings::resetSize()
 		sel->resetShape();
 }
 
+void SelectionSettings::scale()
+{
+	updateSelectionMode(canvas::Selection::AdjustmentMode::Scale);
+}
+
+void SelectionSettings::rotateShear()
+{
+	updateSelectionMode(canvas::Selection::AdjustmentMode::Rotate);
+}
+
+void SelectionSettings::updateSelectionMode(canvas::Selection::AdjustmentMode mode)
+{
+	if(!controller()->model())
+		return;
+
+	canvas::Selection *sel = controller()->model()->selection();
+	if(sel && sel->adjustmentMode() != mode)
+		sel->setAdjustmentMode(mode);
+}
+
+void SelectionSettings::modelChanged(canvas::CanvasModel *model)
+{
+	if(model) {
+		connect(model, &canvas::CanvasModel::selectionChanged, this, &SelectionSettings::selectionChanged);
+		selectionChanged(model->selection());
+	}
+}
+
+void SelectionSettings::selectionChanged(canvas::Selection *selection)
+{
+	setControlsEnabled(selection && selection->isClosed());
+	if(selection) {
+		connect(selection, &canvas::Selection::adjustmentModeChanged, this, &SelectionSettings::selectionAdjustmentModeChanged);
+		connect(selection, &canvas::Selection::closed, this, &SelectionSettings::selectionClosed);
+		selectionAdjustmentModeChanged(selection->adjustmentMode());
+	}
+}
+
+void SelectionSettings::selectionClosed()
+{
+	setControlsEnabled(true);
+}
+
 void SelectionSettings::cutSelection()
 {
 	canvas::Selection *sel = controller()->model()->selection();
@@ -122,6 +170,28 @@ void SelectionSettings::cutSelection()
 
 	if(sel && sel->pasteImage().isNull() && !controller()->model()->aclFilter()->isLayerLocked(layer)) {
 		static_cast<tools::SelectionTool*>(controller()->getTool(Tool::SELECTION))->startMove();
+	}
+}
+
+void SelectionSettings::setControlsEnabled(bool enabled)
+{
+	m_ui->flip->setEnabled(enabled);
+	m_ui->mirror->setEnabled(enabled);
+	m_ui->fittoscreen->setEnabled(enabled);
+	m_ui->resetsize->setEnabled(enabled);
+	m_ui->scale->setEnabled(enabled);
+	m_ui->rotateShear->setEnabled(enabled);
+	if(!enabled) {
+		m_ui->scale->setChecked(true);
+	}
+}
+
+void SelectionSettings::selectionAdjustmentModeChanged(canvas::Selection::AdjustmentMode mode)
+{
+	if(mode == canvas::Selection::AdjustmentMode::Scale) {
+		m_ui->scale->setChecked(true);
+	} else {
+		m_ui->rotateShear->setChecked(true);
 	}
 }
 

--- a/src/desktop/toolwidgets/selectionsettings.h
+++ b/src/desktop/toolwidgets/selectionsettings.h
@@ -65,6 +65,7 @@ private slots:
 	void resetSize();
 	void scale();
 	void rotateShear();
+	void distort();
 	void modelChanged(canvas::CanvasModel *model);
 	void selectionChanged(canvas::Selection *selection);
 	void selectionClosed();

--- a/src/desktop/toolwidgets/selectionsettings.h
+++ b/src/desktop/toolwidgets/selectionsettings.h
@@ -20,8 +20,11 @@
 #define TOOLSETTINGS_SELECTION_H
 
 #include "toolsettings.h"
+#include "tools/selection.h"
 
 class Ui_SelectionSettings;
+
+namespace canvas { class CanvasModel; }
 
 namespace widgets { class CanvasView; }
 
@@ -53,16 +56,25 @@ public:
 	int getSize() const override { return 0; }
 	bool getSubpixelMode() const override { return false; }
 
+	void setControlsEnabled(bool enabled);
+
 private slots:
 	void flipSelection();
 	void mirrorSelection();
 	void fitToScreen();
 	void resetSize();
+	void scale();
+	void rotateShear();
+	void modelChanged(canvas::CanvasModel *model);
+	void selectionChanged(canvas::Selection *selection);
+	void selectionClosed();
+	void selectionAdjustmentModeChanged(canvas::Selection::AdjustmentMode mode);
 
 protected:
 	QWidget *createUiWidget(QWidget *parent) override;
 
 private:
+	void updateSelectionMode(canvas::Selection::AdjustmentMode mode);
 	void cutSelection();
 
 	Ui_SelectionSettings *m_ui;

--- a/src/desktop/ui/selectsettings.ui
+++ b/src/desktop/ui/selectsettings.ui
@@ -86,6 +86,35 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="transforms">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QRadioButton" name="scale">
+        <property name="text">
+         <string>Scale</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rotateShear">
+        <property name="text">
+         <string>Rotate/Shear</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/desktop/ui/selectsettings.ui
+++ b/src/desktop/ui/selectsettings.ui
@@ -111,6 +111,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QRadioButton" name="distort">
+        <property name="text">
+         <string>Distort</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/libclient/canvas/selection.cpp
+++ b/src/libclient/canvas/selection.cpp
@@ -201,8 +201,6 @@ void Selection::adjustGeometryScale(const QPoint &delta, bool keepAspect)
 		case Handle::Left: adjustScale(delta.x(), 0, 0, 0); break;
 		}
 	}
-
-	emit shapeChanged(m_shape);
 }
 
 void Selection::adjustGeometryRotate(const QPointF &start, const QPointF &point, bool constrain)
@@ -252,9 +250,11 @@ void Selection::adjustScale(qreal dx1, qreal dy1, qreal dx2, qreal dy2)
 		if(std::isnan(m_shape[i].x()) || std::isnan(m_shape[i].y())) {
 			qWarning("Selection shape[%d] is Not a Number!", i);
 			m_shape = m_preAdjustmentShape;
-			return;
+			break;
 		}
 	}
+
+	emit shapeChanged(m_shape);
 }
 
 void Selection::adjustRotation(qreal angle)

--- a/src/libclient/canvas/selection.cpp
+++ b/src/libclient/canvas/selection.cpp
@@ -175,7 +175,7 @@ void Selection::adjustGeometryScale(const QPoint &delta, bool keepAspect)
 
 		switch(m_adjustmentHandle) {
 		case Handle::Outside: return;
-		case Handle::Center: m_shape = m_preAdjustmentShape.translated(delta); break;
+		case Handle::Center: adjustTranslation(delta); break;
 
 		case Handle::TopLeft: adjustScale(dx, dy, 0, 0); break;
 		case Handle::TopRight: adjustScale(0, -dx, dy, 0); break;
@@ -190,7 +190,7 @@ void Selection::adjustGeometryScale(const QPoint &delta, bool keepAspect)
 	} else {
 		switch(m_adjustmentHandle) {
 		case Handle::Outside: return;
-		case Handle::Center: m_shape = m_preAdjustmentShape.translated(delta); break;
+		case Handle::Center: adjustTranslation(delta); break;
 		case Handle::TopLeft: adjustScale(delta.x(), delta.y(), 0, 0); break;
 		case Handle::TopRight: adjustScale(0, delta.y(), delta.x(), 0); break;
 		case Handle::BottomRight: adjustScale(0, 0, delta.x(), delta.y()); break;
@@ -207,7 +207,7 @@ void Selection::adjustGeometryRotate(const QPointF &start, const QPointF &point,
 {
 	switch(m_adjustmentHandle) {
 	case Handle::Outside: return;
-	case Handle::Center: m_shape = m_preAdjustmentShape.translated(point - start); break;
+	case Handle::Center: adjustTranslation(point - start); break;
 	case Handle::TopLeft:
 	case Handle::TopRight:
 	case Handle::BottomRight:
@@ -230,6 +230,14 @@ void Selection::adjustGeometryRotate(const QPointF &start, const QPointF &point,
 	case Handle::Left: adjustShear(0, (start.y() - point.y()) / 100.0); break;
 	}
 
+void Selection::adjustTranslation(const QPointF &start, const QPointF &point)
+{
+	adjustTranslation(point - start);
+}
+
+void Selection::adjustTranslation(const QPointF &delta)
+{
+	m_shape = m_preAdjustmentShape.translated(delta);
 	emit shapeChanged(m_shape);
 }
 

--- a/src/libclient/canvas/selection.h
+++ b/src/libclient/canvas/selection.h
@@ -42,7 +42,7 @@ class Selection : public QObject
 	Q_OBJECT
 public:
 	enum class Handle {Outside, Center, TopLeft, TopRight, BottomRight, BottomLeft, Top, Right, Bottom, Left};
-	enum class AdjustmentMode { Scale, Rotate };
+	enum class AdjustmentMode { Scale, Rotate, Distort };
 
 	explicit Selection(QObject *parent=nullptr);
 
@@ -213,11 +213,13 @@ signals:
 private:
 	void adjustGeometryScale(const QPoint &delta, bool keepAspect);
 	void adjustGeometryRotate(const QPointF &start, const QPointF &point, bool constrain);
+	void adjustGeometryDistort(const QPointF &delta);
 	void adjustTranslation(const QPointF &start, const QPointF &point);
 	void adjustTranslation(const QPointF &delta);
 	void adjustScale(qreal dx1, qreal dy1, qreal dx2, qreal dy2);
 	void adjustRotation(qreal angle);
 	void adjustShear(qreal sh, qreal sv);
+	void adjustDistort(const QPointF &delta, int corner1, int corner2 = -1);
 
 	void saveShape();
 

--- a/src/libclient/canvas/selection.h
+++ b/src/libclient/canvas/selection.h
@@ -213,6 +213,8 @@ signals:
 private:
 	void adjustGeometryScale(const QPoint &delta, bool keepAspect);
 	void adjustGeometryRotate(const QPointF &start, const QPointF &point, bool constrain);
+	void adjustTranslation(const QPointF &start, const QPointF &point);
+	void adjustTranslation(const QPointF &delta);
 	void adjustScale(qreal dx1, qreal dy1, qreal dx2, qreal dy2);
 	void adjustRotation(qreal angle);
 	void adjustShear(qreal sh, qreal sv);

--- a/src/libclient/tools/selection.cpp
+++ b/src/libclient/tools/selection.cpp
@@ -104,11 +104,19 @@ void SelectionTool::end()
 
 	// Toggle adjustment mode if just clicked
 	if((m_end - m_start).manhattanLength() < 2.0) {
-		sel->setAdjustmentMode(
-			sel->adjustmentMode() == canvas::Selection::AdjustmentMode::Scale
-				? canvas::Selection::AdjustmentMode::Rotate
-				: canvas::Selection::AdjustmentMode::Scale
-		);
+		canvas::Selection::AdjustmentMode nextMode;
+		switch(sel->adjustmentMode()) {
+		case canvas::Selection::AdjustmentMode::Scale:
+			nextMode = canvas::Selection::AdjustmentMode::Rotate;
+			break;
+		case canvas::Selection::AdjustmentMode::Rotate:
+			nextMode = canvas::Selection::AdjustmentMode::Distort;
+			break;
+		default:
+			nextMode = canvas::Selection::AdjustmentMode::Scale;
+			break;
+		}
+		sel->setAdjustmentMode(nextMode);
 	}
 }
 

--- a/src/libclient/tools/toolcontroller.cpp
+++ b/src/libclient/tools/toolcontroller.cpp
@@ -149,9 +149,8 @@ void ToolController::setModel(canvas::CanvasModel *model)
 		connect(m_model->stateTracker(), &canvas::StateTracker::myAnnotationCreated, this, &ToolController::setActiveAnnotation);
 		connect(m_model->layerStack()->annotations(), &paintcore::AnnotationModel::rowsAboutToBeRemoved, this, &ToolController::onAnnotationRowDelete);
 		connect(m_model->aclFilter(), &canvas::AclFilter::featureAccessChanged, this, &ToolController::onFeatureAccessChange);
-
-		emit modelChanged(model);
 	}
+	emit modelChanged(model);
 }
 
 void ToolController::onAnnotationRowDelete(const QModelIndex&, int first, int last)


### PR DESCRIPTION
A feature that goes by many names in different programs. Lets you do a perspective transform on a selection, something I use all the time.

Also makes some usability improvements to the selection tool panel because I was going slightly mad testing this out. It now disables all the stuff in it when no selection is active and provides a set of radio buttons to switch between the different transformation modes.

I'd like to make more improvements to this to basically make it work more like it does in Krita (which e.g. doesn't have the issue of accidentally clicking outside the selection), but that's unrelated to the direct functionality here, so I think it could be merged already and hopefully be as useful to others.

Showing it off:

https://user-images.githubusercontent.com/13625824/103480108-94cf0c00-4dd2-11eb-9f28-e82264635b0b.mp4

