### PR TITLE
Allow changing the brush cursor outline width

### DIFF
--- a/src/desktop/dialogs/settingsdialog.cpp
+++ b/src/desktop/dialogs/settingsdialog.cpp
@@ -263,6 +263,7 @@ void SettingsDialog::restoreSettings()
 	m_ui->autosaveInterval->setValue(cfg.value("autosave", 5000).toInt() / 1000);
 
 	m_ui->brushCursorBox->setCurrentIndex(cfg.value("brushcursor").toInt());
+	m_ui->brushOutlineWidth->setValue(cfg.value("brushoutlinewidth", 1.0).toReal());
 	m_ui->toolToggleShortcut->setChecked(cfg.value("tooltoggle", true).toBool());
 	m_ui->shareBrushSlotColor->setChecked(cfg.value("sharebrushslotcolor", false).toBool());
 
@@ -381,6 +382,7 @@ void SettingsDialog::rememberSettings()
 	cfg.setValue("settings/logfile", m_ui->logfile->isChecked());
 	cfg.setValue("settings/autosave", m_ui->autosaveInterval->value() * 1000);
 	cfg.setValue("settings/brushcursor", m_ui->brushCursorBox->currentIndex());
+	cfg.setValue("settings/brushoutlinewidth", static_cast<qreal>(m_ui->brushOutlineWidth->value()));
 	cfg.setValue("settings/tooltoggle", m_ui->toolToggleShortcut->isChecked());
 	cfg.setValue("settings/sharebrushslotcolor", m_ui->shareBrushSlotColor->isChecked());
 	cfg.setValue("settings/insecurepasswordstorage", m_ui->insecurePasswordStorage->isChecked());

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -756,7 +756,7 @@ void MainWindow::updateSettings()
 	cfg.endGroup();
 
 	cfg.beginGroup("settings");
-	m_view->setBrushCursorStyle(cfg.value("brushcursor").toInt());
+	m_view->setBrushCursorStyle(cfg.value("brushcursor").toInt(), cfg.value("brushoutlinewidth").toReal());
 	static_cast<tools::BrushSettings*>(m_dockToolSettings->getToolSettingsPage(tools::Tool::FREEHAND))->setShareBrushSlotColor(cfg.value("sharebrushslotcolor", false).toBool());
 }
 

--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -53,7 +53,8 @@ CanvasView::CanvasView(QWidget *parent)
 	m_enableTouchScroll(true), m_enableTouchPinch(true), m_enableTouchTwist(true),
 	m_touching(false), m_touchRotating(false),
 	m_dpi(96),
-	m_brushCursorStyle(0)
+	m_brushCursorStyle(0),
+	m_brushOutlineWidth(1.0)
 {
 	viewport()->setAcceptDrops(true);
 #ifdef Q_OS_MAC // Standard touch events seem to work better with mac touchpad
@@ -260,9 +261,10 @@ void CanvasView::setLocked(bool lock)
 	resetCursor();
 }
 
-void CanvasView::setBrushCursorStyle(int style)
+void CanvasView::setBrushCursorStyle(int style, qreal outlineWidth)
 {
 	m_brushCursorStyle = style;
+	m_brushOutlineWidth = qIsNaN(outlineWidth) || outlineWidth < 1.0 ? 1.0 : outlineWidth;
 	resetCursor();
 }
 
@@ -370,6 +372,7 @@ void CanvasView::drawForeground(QPainter *painter, const QRectF& rect)
 			painter->save();
 			QPen pen(QColor(96, 191, 96));
 			pen.setCosmetic(true);
+			pen.setWidthF(m_brushOutlineWidth);
 			painter->setPen(pen);
 			painter->setCompositionMode(QPainter::RasterOp_SourceXorDestination);
 			if(m_squareoutline)

--- a/src/desktop/scene/canvasview.h
+++ b/src/desktop/scene/canvasview.h
@@ -169,7 +169,7 @@ public slots:
 	 * 1. Crosshair
 	 * 2. Arrow
 	 */
-	void setBrushCursorStyle(int style);
+	void setBrushCursorStyle(int style, qreal outlineWidth);
 
 	void updateShortcuts();
 
@@ -282,6 +282,7 @@ private:
 	qreal m_touchStartZoom, m_touchStartRotate;
 	qreal m_dpi;
 	int m_brushCursorStyle;
+	qreal m_brushOutlineWidth;
 };
 
 }

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -132,6 +132,9 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -263,6 +266,9 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -270,13 +276,6 @@
                </size>
               </property>
              </spacer>
-            </item>
-            <item row="18" column="0">
-             <widget class="QLabel" name="label_16">
-              <property name="text">
-               <string>Brush cursor:</string>
-              </property>
-             </widget>
             </item>
             <item row="18" column="1">
              <widget class="QComboBox" name="brushCursorBox">
@@ -297,10 +296,50 @@
               </item>
              </widget>
             </item>
-            <item row="19" column="1">
+            <item row="23" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Tools:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="23" column="1">
+             <widget class="QCheckBox" name="toolToggleShortcut">
+              <property name="text">
+               <string>Shortcut toggles last selection</string>
+              </property>
+             </widget>
+            </item>
+            <item row="24" column="1">
+             <widget class="QCheckBox" name="shareBrushSlotColor">
+              <property name="text">
+               <string>Share color across brush slots</string>
+              </property>
+             </widget>
+            </item>
+            <item row="20" column="1">
+             <widget class="QDoubleSpinBox" name="brushOutlineWidth">
+              <property name="minimum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>20.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="21" column="1">
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -310,24 +349,17 @@
               </property>
              </spacer>
             </item>
+            <item row="18" column="0">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Brush cursor:</string>
+              </property>
+             </widget>
+            </item>
             <item row="20" column="0">
-             <widget class="QLabel" name="label_2">
+             <widget class="QLabel" name="label_30">
               <property name="text">
-               <string>Tools:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="20" column="1">
-             <widget class="QCheckBox" name="toolToggleShortcut">
-              <property name="text">
-               <string>Shortcut toggles last selection</string>
-              </property>
-             </widget>
-            </item>
-            <item row="21" column="1">
-             <widget class="QCheckBox" name="shareBrushSlotColor">
-              <property name="text">
-               <string>Share color across brush slots</string>
+               <string>Brush outline width:</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Tiny usability feature: I kept losing sight of the brush circle, since it was only a single pixel wide. This adds a setting that allows making it wider. I set it to 2 and haven't lost sight of it since.

https://user-images.githubusercontent.com/13625824/103481184-8506f600-4dd9-11eb-9d39-190c9019b3aa.mp4

