### PR TITLE
Add colorwheel shape, angle and space options

### DIFF
--- a/src/desktop/dialogs/settingsdialog.h
+++ b/src/desktop/dialogs/settingsdialog.h
@@ -30,6 +30,8 @@ class AvatarListModel;
 
 namespace sessionlisting { class ListServerModel; }
 
+namespace color_widgets { class ColorWheel; }
+
 namespace dialogs {
 
 class SettingsDialog : public QDialog
@@ -60,9 +62,18 @@ private slots:
 	void addAvatar();
 	void removeSelectedAvatar();
 
+	void changeColorWheelShape(int index);
+	void changeColorWheelAngle(int index);
+	void changeColorWheelSpace(int index);
+
 private:
+	enum ColorWheelShape { Square, Triangle };
+	enum ColorWheelAngle { Fixed, Rotating };
+	enum ColorWheelSpace { Hsv, Hsl, Lch };
+
 	void restoreSettings();
 	void setParentalControlsLocked(bool lock);
+	void restoreColorWheelSettings(int flags);
 	void rememberPcLevel();
 
 	Ui_SettingsDialog *m_ui;

--- a/src/desktop/docks/colorbox.cpp
+++ b/src/desktop/docks/colorbox.cpp
@@ -22,6 +22,7 @@
 #include <ColorWheel>
 #include <HueSlider>
 
+#include "main.h"
 #include "docks/colorbox.h"
 #include "docks/utils.h"
 #include "utils/palettelistmodel.h"
@@ -33,6 +34,8 @@
 #include <QMessageBox>
 #include <QMenu>
 #include <QFileDialog>
+
+using color_widgets::ColorWheel;
 
 namespace docks {
 
@@ -157,6 +160,10 @@ ColorBox::ColorBox(const QString& title, QWidget *parent)
 
 	connect(_ui->lastused, SIGNAL(colorSelected(QColor)), this, SIGNAL(colorChanged(QColor)));
 	connect(_ui->lastused, SIGNAL(colorSelected(QColor)), this, SLOT(setColor(QColor)));
+
+	connect(static_cast<DrawpileApp*>(qApp), &DrawpileApp::settingsChanged,
+			this, &ColorBox::updateSettings);
+	updateSettings();
 }
 
 ColorBox::~ColorBox()
@@ -310,7 +317,7 @@ void ColorBox::updateFromRgbSliders()
 {
 	if(!_updating) {
 		QColor color(_ui->red->value(), _ui->green->value(), _ui->blue->value());
-				
+
 		setColor(color);
 		emit colorChanged(color);
 	}
@@ -381,6 +388,15 @@ void ColorBox::swapLastUsedColors()
 
 	setColor(altColor);
 	emit colorChanged(altColor);
+}
+
+void ColorBox::updateSettings()
+{
+	QSettings cfg;
+	cfg.beginGroup("settings/colorwheel");
+	_ui->colorwheel->setDisplayFlags(
+			static_cast<ColorWheel::DisplayFlags>(cfg.value("flags").toInt()));
+	cfg.endGroup();
 }
 
 }

--- a/src/desktop/docks/colorbox.h
+++ b/src/desktop/docks/colorbox.h
@@ -55,6 +55,8 @@ private slots:
 	void updateFromHsvSliders();
 	void updateFromHsvSpinbox();
 
+	void updateSettings();
+
 private:
 	Ui_ColorBox *_ui;
 	Palette *m_lastused;

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -341,10 +341,10 @@
           <widget class="QWidget" name="colorwheelPage">
            <layout class="QFormLayout" name="formLayout_9">
             <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::ExpandingFieldsGrow</enum>
+             <enum>QFormLayout::ExpandingFieldsGrow</enum>
             </property>
             <item row="0" column="0">
-             <widget class="QLabel" name="label_30">
+             <widget class="QLabel" name="colorwheelShapeLabel">
               <property name="text">
                <string>Shape:</string>
               </property>
@@ -365,7 +365,7 @@
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_31">
+             <widget class="QLabel" name="colorwheelAngleLabel">
               <property name="text">
                <string>Angle:</string>
               </property>
@@ -386,7 +386,7 @@
              </widget>
             </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="label_32">
+             <widget class="QLabel" name="colorwheelSpaceLabel">
               <property name="text">
                <string>Color Space:</string>
               </property>
@@ -422,7 +422,7 @@
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="label_33">
+             <widget class="QLabel" name="colorwheelPreviewLabel">
               <property name="text">
                <string>Preview:</string>
               </property>

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -339,6 +339,12 @@
            </layout>
           </widget>
           <widget class="QWidget" name="colorwheelPage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <layout class="QFormLayout" name="formLayout_9">
             <property name="fieldGrowthPolicy">
              <enum>QFormLayout::ExpandingFieldsGrow</enum>
@@ -414,10 +420,16 @@
             <item row="3" column="1">
              <widget class="color_widgets::ColorWheel" name="colorwheel" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>300</width>
+                <height>300</height>
+               </size>
               </property>
              </widget>
             </item>

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -25,6 +25,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Color Wheel</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Notifications</string>
         </property>
        </item>
@@ -333,6 +338,98 @@
             </item>
            </layout>
           </widget>
+          <widget class="QWidget" name="colorwheelPage">
+           <layout class="QFormLayout" name="formLayout_9">
+            <property name="fieldGrowthPolicy">
+            <enum>QFormLayout::ExpandingFieldsGrow</enum>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_30">
+              <property name="text">
+               <string>Shape:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="colorwheelShapeBox">
+              <item>
+               <property name="text">
+                <string>Square</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Triangle</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_31">
+              <property name="text">
+               <string>Angle:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="colorwheelAngleBox">
+              <item>
+               <property name="text">
+                <string>Fixed</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Rotating</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_32">
+              <property name="text">
+               <string>Color Space:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="colorwheelSpaceBox">
+              <item>
+               <property name="text">
+                <string>HSV (Hue, Saturation, Value)</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>HSL (Hue, Saturation, Lightness)</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Lch (Luminance, Chroma, Hue)</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="color_widgets::ColorWheel" name="colorwheel" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_33">
+              <property name="text">
+               <string>Preview:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
           <widget class="QWidget" name="page_2">
            <layout class="QFormLayout" name="formLayout_6">
             <item row="0" column="0">
@@ -375,6 +472,13 @@
               </item>
              </layout>
             </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>Notifications:</string>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="1">
              <widget class="QCheckBox" name="notifChat">
               <property name="text">
@@ -400,13 +504,6 @@
              <widget class="QCheckBox" name="notifLock">
               <property name="text">
                <string>Canvas lock</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>Notifications:</string>
               </property>
              </widget>
             </item>
@@ -1121,6 +1218,11 @@
    <class>widgets::ModifierKeys</class>
    <extends>QWidget</extends>
    <header>widgets/modifierkeys.h</header>
+  </customwidget>
+  <customwidget>
+   <class>color_widgets::ColorWheel</class>
+   <extends>QWidget</extends>
+   <header>ColorWheel</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
A new tab in preferences allows you to set these and wires them up to
the matching options in the ColorWheel class. If no settings exist yet,
it'll default to a rectangular, fixed colorwheel with a square shape, as
before.

From my testing, the Lch color space acts in a really confusing manner.
I guess this would make sense to people who know how to work it, but I
dunno if it's actually a use case for Drawpile, so maybe it could be
removed to avoid bug reports by users that are as perplexed by the
behavior as I am.

Attached is a video of it in action.

https://user-images.githubusercontent.com/13625824/123676494-4ca21b00-d844-11eb-825e-f35697bc9014.mp4