### PR TITLE
Improve input presets dialog

### DIFF
--- a/src/desktop/dialogs/inputsettings.cpp
+++ b/src/desktop/dialogs/inputsettings.cpp
@@ -126,6 +126,7 @@ void InputSettings::applyPresetToUi(const input::Preset &preset)
 		m_ui->pressuresrc->setCurrentIndex(preset.curve.mode);
 		m_ui->curve->setCurve(preset.curve.curve);
 		m_ui->curveParam->setValue(int(preset.curve.param * 100.0));
+		updateModeUi(preset.curve.mode);
 		m_updateInProgress = false;
 	}
 }
@@ -150,7 +151,31 @@ void InputSettings::applyUiToPreset()
 				}
 			}
 		);
+		updateModeUi(current->curve.mode);
 	}
+}
+
+void InputSettings::updateModeUi(PressureMapping::Mode mode)
+{
+	const char *curveParam;
+	switch(mode) {
+	case PressureMapping::STYLUS:
+		curveParam = nullptr;
+		break;
+	case PressureMapping::DISTANCE:
+		curveParam = "Curve distance";
+		break;
+	case PressureMapping::VELOCITY:
+		curveParam = "Velocity range";
+		break;
+	default:
+		break;
+	}
+	m_ui->curveParam->setVisible(curveParam != nullptr);
+#if QT_CONFIG(tooltip)
+	m_ui->curveParam->setToolTip(QCoreApplication::translate(
+			"InputSettings", curveParam, nullptr));
+#endif
 }
 
 }

--- a/src/desktop/dialogs/inputsettings.cpp
+++ b/src/desktop/dialogs/inputsettings.cpp
@@ -23,6 +23,7 @@
 #include "ui_inputcfg.h"
 
 #include <QDebug>
+#include <qpushbutton.h>
 
 namespace dialogs {
 
@@ -54,6 +55,8 @@ InputSettings::InputSettings(QWidget *parent) :
 	connect(m_ui->preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &InputSettings::choosePreset);
 	connect(m_presetModel, &QAbstractItemModel::rowsRemoved, this, &InputSettings::onPresetCountChanged);
 	connect(m_presetModel, &QAbstractItemModel::modelReset, this, &InputSettings::onPresetCountChanged);
+
+	connect(m_ui->closeButton, &QPushButton::pressed, this, &QDialog::reject);
 
 	onPresetCountChanged();
 }

--- a/src/desktop/dialogs/inputsettings.cpp
+++ b/src/desktop/dialogs/inputsettings.cpp
@@ -53,6 +53,7 @@ InputSettings::InputSettings(QWidget *parent) :
 
 	connect(m_ui->preset, &QComboBox::editTextChanged, this, &InputSettings::presetNameChanged);
 	connect(m_ui->preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &InputSettings::choosePreset);
+	connect(m_presetModel, &QAbstractItemModel::rowsInserted, this, &InputSettings::onPresetCountChanged);
 	connect(m_presetModel, &QAbstractItemModel::rowsRemoved, this, &InputSettings::onPresetCountChanged);
 	connect(m_presetModel, &QAbstractItemModel::modelReset, this, &InputSettings::onPresetCountChanged);
 

--- a/src/desktop/dialogs/inputsettings.h
+++ b/src/desktop/dialogs/inputsettings.h
@@ -56,6 +56,7 @@ private:
 
 	void applyPresetToUi(const input::Preset &preset);
 	void applyUiToPreset();
+	void updateModeUi(PressureMapping::Mode mode);
 
 	Ui_InputSettings *m_ui;
 	input::PresetModel *m_presetModel;

--- a/src/desktop/dialogs/inputsettings.h
+++ b/src/desktop/dialogs/inputsettings.h
@@ -43,6 +43,12 @@ public:
 	void setCurrentPreset(const QString &id);
 	const input::Preset *currentPreset() const;
 
+signals:
+	void currentIndexChanged(int index);
+
+public slots:
+	void setCurrentIndex(int index);
+
 private slots:
 	void choosePreset(int index);
 	void presetNameChanged(const QString &name);
@@ -61,6 +67,7 @@ private:
 	Ui_InputSettings *m_ui;
 	input::PresetModel *m_presetModel;
 	bool m_updateInProgress;
+	bool m_indexChangeInProgress;
 	QMenu *m_presetmenu;
 	QAction *m_removePresetAction;
 };

--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -163,6 +163,10 @@ QWidget *BrushSettings::createUiWidget(QWidget *parent)
 		if(!d->inputSettingsDialog) {
 			d->inputSettingsDialog = new dialogs::InputSettings(parent);
 			d->inputSettingsDialog->setAttribute(Qt::WA_DeleteOnClose);
+			connect(d->inputSettingsDialog, &dialogs::InputSettings::currentIndexChanged,
+					d->ui.inputPreset, &QComboBox::setCurrentIndex);
+			connect(d->ui.inputPreset, QOverload<int>::of(&QComboBox::currentIndexChanged),
+					d->inputSettingsDialog, &dialogs::InputSettings::setCurrentIndex);
 		}
 		d->inputSettingsDialog->setCurrentPreset(d->currentTool().inputPresetId);
 		d->inputSettingsDialog->show();

--- a/src/desktop/ui/brushdock.ui
+++ b/src/desktop/ui/brushdock.ui
@@ -612,6 +612,9 @@
      </item>
      <item row="6" column="3">
       <widget class="widgets::GroupedToolButton" name="configureInput">
+       <property name="toolTip">
+        <string>Configure input presets</string>
+       </property>
        <property name="icon">
         <iconset theme="configure">
          <normaloff>theme:configure.svg</normaloff>theme:configure.svg</iconset>

--- a/src/desktop/ui/inputcfg.ui
+++ b/src/desktop/ui/inputcfg.ui
@@ -6,25 +6,25 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>263</width>
-    <height>255</height>
+    <width>350</width>
+    <height>400</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>5</number>
+    <number>6</number>
    </property>
    <property name="leftMargin">
-    <number>3</number>
+    <number>9</number>
    </property>
    <property name="topMargin">
-    <number>3</number>
+    <number>9</number>
    </property>
    <property name="rightMargin">
-    <number>3</number>
+    <number>9</number>
    </property>
    <property name="bottomMargin">
-    <number>3</number>
+    <number>9</number>
    </property>
    <item>
     <layout class="QFormLayout" name="formLayout">
@@ -152,6 +152,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QSlider" name="curveParam">
+       <property name="minimumSize">
+        <size>
+         <width>24</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Velocity range</string>
        </property>
@@ -177,11 +183,41 @@
      </item>
      <item>
       <widget class="KisCurveWidget" name="curve" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
          <width>50</width>
          <height>50</height>
         </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This amends changes made by @callaa to move the input presets from their own tool thingy into a dialog. Adds a few things to make it look and behave reasonably.

* Sensible padding around the edges and between its elements, in line with other dialogs.

* A minimum size for the bar on the left so the handle doesn't get clipped on the left.

* Expanding vertical layout policy for the curve. Otherwise hiding the bar on the left will cause it to collapse.

* A close button at the bottom. It would be more in line with other preferences to have this be a set of OK and Cancel buttons instead, but since you probably want to be trying out your input settings while you're adjusting them, this is probably fine.

* A tooltip on the edit presets button.

* Hiding and showing the slider bar on the left depending on which input mode is chosen. This slider does nothing for stylus input, so it's hidden for that one, the other two have it shown

* Said slider also gets proper tooltips now, talking about distance and velocity depending on which is selected. Before it always talked about velocity.

This is what it looks like:

https://user-images.githubusercontent.com/13625824/124179265-dfe08800-dab2-11eb-8b6e-bb470c11c6a2.mp4