### PR TITLE
Implement canvas viewport entry hack

### DIFF
--- a/src/desktop/dialogs/settingsdialog.cpp
+++ b/src/desktop/dialogs/settingsdialog.cpp
@@ -124,11 +124,6 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 	m_ui->relativePenModeHack->hide();
 #endif
 
-	// Same for Linux-specific hacks.
-#if !defined(Q_OS_LINUX)
-	m_ui->viewportEntryHack->hide();
-#endif
-
 	// Editable shortcuts
 	m_customShortcuts = new CustomShortcutModel(this);
 	auto filteredShortcuts = new QSortFilterProxyModel(this);
@@ -280,9 +275,7 @@ void SettingsDialog::restoreSettings()
 	m_ui->windowsink->setChecked(cfg.value("windowsink", true).toBool());
 	m_ui->relativePenModeHack->setChecked(cfg.value("relativepenhack", false).toBool());
 #endif
-#if defined(Q_OS_LINUX)
 	m_ui->viewportEntryHack->setChecked(cfg.value("viewportentryhack").toBool());
-#endif
 	m_ui->tabletSupport->setChecked(cfg.value("tabletevents", true).toBool());
 	m_ui->tabletEraser->setChecked(cfg.value("tableteraser", true).toBool());
 #ifdef Q_OS_MAC
@@ -398,9 +391,7 @@ void SettingsDialog::rememberSettings()
 	cfg.setValue("windowsink", m_ui->windowsink->isChecked());
 	cfg.setValue("relativepenhack", m_ui->relativePenModeHack->isChecked());
 #endif
-#if defined(Q_OS_LINUX)
 	cfg.setValue("viewportentryhack", m_ui->viewportEntryHack->isChecked());
-#endif
 	cfg.setValue("tabletevents", m_ui->tabletSupport->isChecked());
 	cfg.setValue("tableteraser", m_ui->tabletEraser->isChecked());
 	cfg.setValue("touchscroll", m_ui->touchscroll->isChecked());

--- a/src/desktop/dialogs/settingsdialog.cpp
+++ b/src/desktop/dialogs/settingsdialog.cpp
@@ -124,6 +124,11 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 	m_ui->relativePenModeHack->hide();
 #endif
 
+	// Same for Linux-specific hacks.
+#if !defined(Q_OS_LINUX)
+	m_ui->viewportEntryHack->hide();
+#endif
+
 	// Editable shortcuts
 	m_customShortcuts = new CustomShortcutModel(this);
 	auto filteredShortcuts = new QSortFilterProxyModel(this);
@@ -275,6 +280,9 @@ void SettingsDialog::restoreSettings()
 	m_ui->windowsink->setChecked(cfg.value("windowsink", true).toBool());
 	m_ui->relativePenModeHack->setChecked(cfg.value("relativepenhack", false).toBool());
 #endif
+#if defined(Q_OS_LINUX)
+	m_ui->viewportEntryHack->setChecked(cfg.value("viewportentryhack").toBool());
+#endif
 	m_ui->tabletSupport->setChecked(cfg.value("tabletevents", true).toBool());
 	m_ui->tabletEraser->setChecked(cfg.value("tableteraser", true).toBool());
 #ifdef Q_OS_MAC
@@ -389,6 +397,9 @@ void SettingsDialog::rememberSettings()
 #if defined(Q_OS_WIN) && defined(KIS_TABLET)
 	cfg.setValue("windowsink", m_ui->windowsink->isChecked());
 	cfg.setValue("relativepenhack", m_ui->relativePenModeHack->isChecked());
+#endif
+#if defined(Q_OS_LINUX)
+	cfg.setValue("viewportentryhack", m_ui->viewportEntryHack->isChecked());
 #endif
 	cfg.setValue("tabletevents", m_ui->tabletSupport->isChecked());
 	cfg.setValue("tableteraser", m_ui->tabletEraser->isChecked());

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -758,6 +758,11 @@ void MainWindow::updateSettings()
 	cfg.beginGroup("settings");
 	m_view->setBrushCursorStyle(cfg.value("brushcursor").toInt());
 	static_cast<tools::BrushSettings*>(m_dockToolSettings->getToolSettingsPage(tools::Tool::FREEHAND))->setShareBrushSlotColor(cfg.value("sharebrushslotcolor", false).toBool());
+	cfg.endGroup();
+
+	cfg.beginGroup("settings/input");
+	m_view->setEnableViewportEntryHack(cfg.value("viewportentryhack").toBool());
+	cfg.endGroup();
 }
 
 void MainWindow::updateLayerViewMode()

--- a/src/desktop/scene/canvasview.h
+++ b/src/desktop/scene/canvasview.h
@@ -173,6 +173,8 @@ public slots:
 
 	void updateShortcuts();
 
+	void setEnableViewportEntryHack(bool enabled);
+
 protected:
 	void enterEvent(QEvent *event) override;
 	void leaveEvent(QEvent *event) override;
@@ -282,6 +284,13 @@ private:
 	qreal m_touchStartZoom, m_touchStartRotate;
 	qreal m_dpi;
 	int m_brushCursorStyle;
+
+	// On some Linux systems, the viewport doesn't properly trigger mouse enter
+	// events through tablet move events, which causes the cursor to not update.
+	// This hack leaves those events unaccepted, which causes a mouse move event
+	// to be synthesized. This is picked up by the viewport and ignored by the
+	// canvas view by checking for the synthetic flag.
+	bool m_enableViewportEntryHack;
 };
 
 }

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -171,14 +171,14 @@
               </property>
              </widget>
             </item>
-            <item row="9" column="1">
+            <item row="10" column="1">
              <widget class="QCheckBox" name="tabletEraser">
               <property name="text">
                <string>Detect eraser tip</string>
               </property>
              </widget>
             </item>
-            <item row="10" column="1">
+            <item row="11" column="1">
              <spacer name="verticalSpacer_5">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -194,35 +194,35 @@
               </property>
              </spacer>
             </item>
-            <item row="11" column="0">
+            <item row="12" column="0">
              <widget class="QLabel" name="label_12">
               <property name="text">
                <string>Touch:</string>
               </property>
              </widget>
             </item>
-            <item row="11" column="1">
+            <item row="12" column="1">
              <widget class="QCheckBox" name="touchscroll">
               <property name="text">
                <string>Scroll with finger</string>
               </property>
              </widget>
             </item>
-            <item row="12" column="1">
+            <item row="13" column="1">
              <widget class="QCheckBox" name="touchpinch">
               <property name="text">
                <string>Pinch to zoom</string>
               </property>
              </widget>
             </item>
-            <item row="13" column="1">
+            <item row="14" column="1">
              <widget class="QCheckBox" name="touchtwist">
               <property name="text">
                <string>Twist to rotate</string>
               </property>
              </widget>
             </item>
-            <item row="14" column="1">
+            <item row="15" column="1">
              <spacer name="verticalSpacer_3">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -238,14 +238,14 @@
               </property>
              </spacer>
             </item>
-            <item row="16" column="0">
+            <item row="17" column="0">
              <widget class="QLabel" name="label_11">
               <property name="text">
                <string>Autosave interval:</string>
               </property>
              </widget>
             </item>
-            <item row="16" column="1">
+            <item row="17" column="1">
              <widget class="QSpinBox" name="autosaveInterval">
               <property name="suffix">
                <string> s</string>
@@ -258,7 +258,7 @@
               </property>
              </widget>
             </item>
-            <item row="17" column="1">
+            <item row="18" column="1">
              <spacer name="verticalSpacer_9">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -271,14 +271,14 @@
               </property>
              </spacer>
             </item>
-            <item row="18" column="0">
+            <item row="19" column="0">
              <widget class="QLabel" name="label_16">
               <property name="text">
                <string>Brush cursor:</string>
               </property>
              </widget>
             </item>
-            <item row="18" column="1">
+            <item row="19" column="1">
              <widget class="QComboBox" name="brushCursorBox">
               <item>
                <property name="text">
@@ -297,7 +297,7 @@
               </item>
              </widget>
             </item>
-            <item row="19" column="1">
+            <item row="20" column="1">
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -310,24 +310,34 @@
               </property>
              </spacer>
             </item>
-            <item row="20" column="0">
+            <item row="21" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
                <string>Tools:</string>
               </property>
              </widget>
             </item>
-            <item row="20" column="1">
+            <item row="21" column="1">
              <widget class="QCheckBox" name="toolToggleShortcut">
               <property name="text">
                <string>Shortcut toggles last selection</string>
               </property>
              </widget>
             </item>
-            <item row="21" column="1">
+            <item row="22" column="1">
              <widget class="QCheckBox" name="shareBrushSlotColor">
               <property name="text">
                <string>Share color across brush slots</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <widget class="QCheckBox" name="viewportEntryHack">
+              <property name="toolTip">
+               <string>Enable this workaround if your cursor doesn't update when you move it into the canvas with the tablet pen.</string>
+              </property>
+              <property name="text">
+               <string>Enable canvas viewport entry hack (Linux only)</string>
               </property>
              </widget>
             </item>

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -337,7 +337,7 @@
                <string>Enable this workaround if your cursor doesn't update when you move it into the canvas with the tablet pen.</string>
               </property>
               <property name="text">
-               <string>Enable canvas viewport entry hack (Linux only)</string>
+               <string>Enable canvas viewport entry hack</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
On my Linux system, when entering the canvas viewport via tablet, the cursor doesn't update properly. This implements a workaround that allows Qt to generate synthetic mouse events for tablet move events, which function properly. The canvas view filters out these synthetic events when the hack is enabled, which means that there should be no change in behavior.

For reference: this is Arch Linux with whatever current Qt5 it comes with, the issue has been there since forever I think. This might be worth raising as an issue with Qt itself, but that'd need a more minimal example to show off the issue in isolation.

This video shows the issue in action. When I move the cursor into the canvas viewport with my tablet, it remains a regular arrow cursor and doesn't have the rectangle tool symbol next to it. After enabling the hack, the cursor behaves properly.

https://user-images.githubusercontent.com/13625824/124194353-b7fc1f00-dac8-11eb-9e22-e32c63922ec4.mp4