### PR TITLE
Allow moving a layer to the bottom-most spot

### DIFF
--- a/src/libclient/canvas/layerlist.cpp
+++ b/src/libclient/canvas/layerlist.cpp
@@ -107,7 +107,11 @@ void LayerListModel::handleMoveLayer(int oldIdx, int newIdx)
 	if(count < 2)
 		return;
 
-	if(oldIdx<0 || oldIdx >= count || newIdx<0 || newIdx >= count) {
+	// If we're moving the layer to a higher index, take into
+	// account that all previous indexes shift down by one.
+	int adjustedNewIdx = newIdx > oldIdx ? newIdx - 1 : newIdx;
+
+	if(oldIdx < 0 || oldIdx >= count || adjustedNewIdx < 0 || adjustedNewIdx >= count) {
 		// This can happen when a layer is deleted while someone is drag&dropping it
 		qWarning("Whoops, can't move layer from %d to %d because it was just deleted!", oldIdx, newIdx);
 		return;
@@ -118,10 +122,7 @@ void LayerListModel::handleMoveLayer(int oldIdx, int newIdx)
 	for(const LayerListItem &li : m_items)
 		layers.append(li.id);
 
-	if(newIdx>oldIdx)
-		--newIdx;
-
-	layers.move(oldIdx, newIdx);
+	layers.move(oldIdx, adjustedNewIdx);
 
 	// Layers are shown topmost first in the list but
 	// are sent bottom first in the protocol.


### PR DESCRIPTION
Before it wouldn't let you do it due to an off-by-one error. If a layer is moved down (to a higher index), the code would decrement the target index by one to account for the indexes shifting by one, but only did so *after* checking if the operation was okay. Now the check uses the correct target index.

This causes no breakage when drawing together with folks that don't have this fix, since the command that's sent always transmits the entire resulting layer order, rather than just the move operation.

Old behavior: Drawpile refuses to move the layer to the bottom, but moving the bottom layer up is fine.

https://user-images.githubusercontent.com/13625824/124322912-9d857c80-db80-11eb-8136-f1d75000653b.mp4

New behavior: layer goes to the bottom as it should.

https://user-images.githubusercontent.com/13625824/124322929-aaa26b80-db80-11eb-841b-97a31d660ec2.mp4