### PR TITLE
Don't scroll the layer list around involuntarily

### DIFF
--- a/src/desktop/docks/layerlistdock.cpp
+++ b/src/desktop/docks/layerlistdock.cpp
@@ -219,26 +219,30 @@ void LayerList::layerContextMenu(const QPoint &pos)
 
 void LayerList::selectLayer(int id)
 {
-	const QModelIndex i = m_canvas->layerlist()->layerIndex(id);
+	selectLayerIndex(m_canvas->layerlist()->layerIndex(id));
+}
 
-	m_ui->layerlist->selectionModel()->select(i, QItemSelectionModel::SelectCurrent|QItemSelectionModel::Clear);
-	m_ui->layerlist->scrollTo(i);
+void LayerList::selectLayerIndex(QModelIndex index, bool scrollTo)
+{
+	if(index.isValid()) {
+		m_ui->layerlist->selectionModel()->select(
+			index, QItemSelectionModel::SelectCurrent|QItemSelectionModel::Clear);
+		if(scrollTo) {
+			m_ui->layerlist->scrollTo(index);
+		}
+	}
 }
 
 void LayerList::selectAbove()
 {
 	QModelIndex current = currentSelection();
-	QModelIndex prev = current.sibling(current.row() - 1, 0);
-	if(prev.isValid())
-		m_ui->layerlist->selectionModel()->select(prev, QItemSelectionModel::SelectCurrent|QItemSelectionModel::Clear);
+	selectLayerIndex(current.sibling(current.row() - 1, 0), true);
 }
 
 void LayerList::selectBelow()
 {
 	QModelIndex current = currentSelection();
-	QModelIndex prev = current.sibling(current.row() + 1, 0);
-	if(prev.isValid())
-		m_ui->layerlist->selectionModel()->select(prev, QItemSelectionModel::SelectCurrent|QItemSelectionModel::Clear);
+	selectLayerIndex(current.sibling(current.row() + 1, 0), true);
 }
 
 void LayerList::opacityAdjusted()
@@ -499,7 +503,7 @@ void LayerList::onLayerDelete(const QModelIndex &, int first, int last)
 	// Automatically select neighbouring on deletion
 	if(row >= first && row <= last) {
 		row = qBound(0, row, m_canvas->layerlist()->rowCount()-1);
-		selectLayer(m_canvas->layerlist()->index(row).data(canvas::LayerListModel::IdRole).toInt());
+		selectLayerIndex(m_canvas->layerlist()->index(row), true);
 	}
 }
 

--- a/src/desktop/docks/layerlistdock.h
+++ b/src/desktop/docks/layerlistdock.h
@@ -106,6 +106,7 @@ private:
 	bool canMergeCurrent() const;
 
 	QModelIndex currentSelection() const;
+	void selectLayerIndex(QModelIndex index, bool scrollTo=false);
 
 	Ui_LayerBox *m_ui;
 	canvas::CanvasModel *m_canvas;


### PR DESCRIPTION
It happens far too frequently that I'm scrolling around in the layers and an errant undo from another user suddenly jerks my scroll position back to the selected layer. Like this (watch the layer list in the bottom-right corner):

https://user-images.githubusercontent.com/13625824/124327509-513e3a80-db88-11eb-9c27-9acaf31f2dd6.mp4

This patch causes scrolling to be restricted to intentional operations, like moving to a next or previous layer:

https://user-images.githubusercontent.com/13625824/124327530-58fddf00-db88-11eb-80e1-5cfacf4c045a.mp4

Partially fixes #593. If you try to rename a layer it still obliterates your edit control, but I have an idea how to make that issue obsolete.