### PR TITLE
Allow increasing the brush slider limits

### DIFF
--- a/src/desktop/dialogs/settingsdialog.cpp
+++ b/src/desktop/dialogs/settingsdialog.cpp
@@ -23,6 +23,7 @@
 #include "dialogs/certificateview.h"
 #include "dialogs/avatarimport.h"
 #include "dialogs/addserverdialog.h"
+#include "../toolwidgets/brushsettings.h"
 #include "widgets/keysequenceedit.h"
 #include "../scene/canvasviewmodifiers.h"
 #include "utils/icon.h"
@@ -347,6 +348,13 @@ void SettingsDialog::restoreSettings()
 	m_ui->toolConstrain2Keys->setModifiers(viewShortcuts.toolConstraint2);
 	cfg.endGroup();
 
+	cfg.beginGroup("settings/brushsliderlimits");
+	m_ui->sizeLimitSpinner->setValue(cfg.value(
+			"size", tools::BrushSettings::DEFAULT_BRUSH_SIZE).toInt());
+	m_ui->spacingLimitSpinner->setValue(cfg.value(
+			"spacing", tools::BrushSettings::DEFAULT_BRUSH_SPACING).toInt());
+	cfg.endGroup();
+
 	m_customShortcuts->loadShortcuts();
 	m_avatars->loadAvatars();
 }
@@ -445,6 +453,11 @@ void SettingsDialog::rememberSettings()
 	viewShortcuts.toolConstraint1 = m_ui->toolConstrain1Keys->modifiers();
 	viewShortcuts.toolConstraint2 = m_ui->toolConstrain2Keys->modifiers();
 	viewShortcuts.save(cfg);
+	cfg.endGroup();
+
+	cfg.beginGroup("settings/brushsliderlimits");
+	cfg.setValue("size", m_ui->sizeLimitSpinner->value());
+	cfg.setValue("spacing", m_ui->spacingLimitSpinner->value());
 	cfg.endGroup();
 
 	if(!parentalcontrols::isLocked())

--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "brushsettings.h"
+#include "main.h"
 #include "tools/toolcontroller.h"
 #include "tools/toolproperties.h"
 #include "brushes/brush.h"
@@ -34,6 +35,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPointer>
+#include <qapplication.h>
+#include <qglobal.h>
 
 namespace tools {
 
@@ -143,6 +146,11 @@ struct BrushSettings::Private {
 	}
 };
 
+const int BrushSettings::MAX_BRUSH_SIZE = 255;
+const int BrushSettings::MAX_BRUSH_SPACING = 999;
+const int BrushSettings::DEFAULT_BRUSH_SIZE = 128;
+const int BrushSettings::DEFAULT_BRUSH_SPACING = 50;
+
 BrushSettings::BrushSettings(ToolController *ctrl, QObject *parent)
 	: ToolSettings(ctrl, parent), d(new Private(this))
 {
@@ -207,6 +215,10 @@ QWidget *BrushSettings::createUiWidget(QWidget *parent)
 	for(int i=0;i<BRUSH_COUNT;++i) {
 		connect(d->brushSlotButton(i), &QToolButton::clicked, this, [this, i]() { selectBrushSlot(i); });
 	}
+
+	connect(static_cast<DrawpileApp*>(qApp), &DrawpileApp::settingsChanged,
+			this, &BrushSettings::updateSettings);
+	updateSettings();
 
 	return widget;
 }
@@ -486,6 +498,19 @@ PressureMapping BrushSettings::getPressureMapping() const
 {
 	const input::Preset *preset = d->currentPreset();
 	return preset ? preset->curve : PressureMapping{};
+}
+
+void BrushSettings::updateSettings()
+{
+	QSettings cfg;
+	cfg.beginGroup("settings/brushsliderlimits");
+	d->ui.brushsizeSlider->setMaximum(qMin(
+			cfg.value("size", DEFAULT_BRUSH_SIZE).toInt(),
+			MAX_BRUSH_SIZE));
+	d->ui.brushspacingSlider->setMaximum(qMin(
+			cfg.value("spacing", DEFAULT_BRUSH_SPACING).toInt(),
+			MAX_BRUSH_SPACING));
+	cfg.endGroup();
 }
 
 namespace toolprop {

--- a/src/desktop/toolwidgets/brushsettings.h
+++ b/src/desktop/toolwidgets/brushsettings.h
@@ -71,6 +71,11 @@ public:
 	int getSmoothing() const;
 	PressureMapping getPressureMapping() const;
 
+	static const int MAX_BRUSH_SIZE;
+	static const int MAX_BRUSH_SPACING;
+	static const int DEFAULT_BRUSH_SIZE;
+	static const int DEFAULT_BRUSH_SPACING;
+
 public slots:
 	void selectBrushSlot(int i);
 	void selectEraserSlot(bool eraser);
@@ -93,6 +98,7 @@ private slots:
 	void updateFromUi();
 	void chooseInputPreset(int index);
 	void inputPresetChanged(const QString &id);
+	void updateSettings();
 
 private:
 	void emitPresetChanges(const input::Preset *preset);

--- a/src/desktop/ui/settings.ui
+++ b/src/desktop/ui/settings.ui
@@ -25,6 +25,11 @@
        </item>
        <item>
         <property name="text">
+         <string>Brushes</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Notifications</string>
         </property>
        </item>
@@ -330,6 +335,114 @@
                <string>Share color across brush slots</string>
               </property>
              </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="brushPage">
+           <layout class="QFormLayout" name="brushFormLayout">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::ExpandingFieldsGrow</enum>
+            </property>
+            <property name="topMargin">
+             <number>19</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="sizeLimitLabel">
+              <property name="toolTip">
+               <string>The maximum value for the brush size slider. You can always enter larger values manually or via keyboard shortcuts.</string>
+              </property>
+              <property name="text">
+               <string>Size Slider Limit:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <layout class="QHBoxLayout" name="sizeLimitLayout">
+              <item>
+               <widget class="QSlider" name="sizeLimitSlider">
+                <property name="toolTip">
+                 <string>The maximum value for the brush size slider. You can always enter larger values manually or via keyboard shortcuts.</string>
+                </property>
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="sizeLimitSpinner">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>The maximum value for the brush size slider. You can always enter larger values manually or via keyboard shortcuts.</string>
+                </property>
+                <property name="suffix">
+                 <string>px</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="spacingLimitLabel">
+              <property name="toolTip">
+               <string>The maximum value for the brush spacing slider. You can always enter larger values manually.</string>
+              </property>
+              <property name="text">
+               <string>Spacing Slider Limit:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="spacingLimitLayout">
+              <item>
+               <widget class="QSlider" name="spacingLimitSlider">
+                <property name="toolTip">
+                 <string>The maximum value for the brush spacing slider. You can always enter larger values manually.</string>
+                </property>
+                <property name="maximum">
+                 <number>999</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="spacingLimitSpinner">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>The maximum value for the brush spacing slider. You can always enter larger values manually.</string>
+                </property>
+                <property name="suffix">
+                 <string>%</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>999</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </widget>
@@ -1170,6 +1283,70 @@
     <hint type="destinationlabel">
      <x>394</x>
      <y>241</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sizeLimitSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>sizeLimitSpinner</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>479</x>
+     <y>52</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>704</x>
+     <y>52</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sizeLimitSpinner</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>sizeLimitSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>704</x>
+     <y>52</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>479</x>
+     <y>52</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spacingLimitSlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>spacingLimitSpinner</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>479</x>
+     <y>86</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>704</x>
+     <y>86</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spacingLimitSpinner</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>spacingLimitSlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>704</x>
+     <y>86</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>479</x>
+     <y>86</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
The size and spacing sliders have arbitrary limits below their actual maximum. You can still go beyond the maximum by using the spinner or keyboard shortcuts, but that's kind of annoying. This patch adds settings to adjust the slider limits to your leisure.

Fixes #847.

Showing it off:

https://user-images.githubusercontent.com/13625824/124339455-e6542a00-dbae-11eb-8a6d-cc5e5d0ed81c.mp4