### PR TITLE
Layer Properties Dialog

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -50,6 +50,7 @@ set (
 	dialogs/versioncheckdialog.cpp
 	dialogs/addserverdialog.cpp
 	dialogs/inputsettings.cpp
+	dialogs/layerproperties.cpp
 	widgets/viewstatus.cpp
 	widgets/palettewidget.cpp 
 	widgets/popupmessage.cpp
@@ -166,6 +167,7 @@ set (
 	ui/avatarimport.ui
 	ui/navigator.ui
 	ui/versioncheck.ui
+	ui/layerproperties.ui
 )
 
 # Use bundled QtColorWidgets widgets if library not found

--- a/src/desktop/dialogs/layerproperties.cpp
+++ b/src/desktop/dialogs/layerproperties.cpp
@@ -1,0 +1,138 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2007-2021 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "layerproperties.h"
+#include "ui_layerproperties.h"
+
+#include "core/blendmodes.h"
+#include "canvas/layerlist.h"
+
+namespace dialogs {
+
+LayerProperties::LayerProperties(QWidget *parent)
+    : QDialog(parent)
+{
+    m_ui = new Ui_LayerProperties;
+    m_ui->setupUi(this);
+
+	for(auto bm : paintcore::getBlendModeNames(paintcore::BlendMode::LayerMode)) {
+		m_ui->blendMode->addItem(bm.second, bm.first);
+    }
+
+    connect(m_ui->title, &QLineEdit::returnPressed, this, &QDialog::accept);
+    connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(this, &QDialog::accepted, this, &LayerProperties::emitChanges);
+}
+
+void LayerProperties::setLayerData(const LayerData &data)
+{
+    m_layerData = data;
+    applyLayerDataToUi();
+}
+
+void LayerProperties::showEvent(QShowEvent *event)
+{
+    QDialog::showEvent(event);
+    m_ui->title->setFocus(Qt::PopupFocusReason);
+    m_ui->title->selectAll();
+}
+
+void LayerProperties::emitChanges()
+{
+    ChangedLayerData c;
+    c.id = m_layerData.id;
+    c.changes = CHANGE_NOTHING;
+
+    c.title = m_ui->title->text();
+    if(c.title != m_layerData.title) {
+        c.changes |= CHANGE_TITLE;
+    }
+
+    int opacity = m_ui->opacitySpinner->value();
+    if(opacity != layerDataOpacity()) {
+        c.opacity = opacity / 100.0f;
+        c.changes |= CHANGE_OPACITY;
+    }
+
+    if(m_ui->blendMode->isEnabled()) {
+        c.blend = static_cast<paintcore::BlendMode::Mode>(
+                m_ui->blendMode->currentData().toInt());
+        if(c.blend != m_layerData.blend) {
+            c.changes |= CHANGE_BLEND;
+        }
+    }
+
+    c.hidden = !m_ui->visible->isChecked();
+    if(c.hidden != m_layerData.hidden) {
+        c.changes |= CHANGE_HIDDEN;
+    }
+
+    c.fixed = m_ui->fixed->isChecked();
+    if(c.fixed != m_layerData.fixed) {
+        c.changes |= CHANGE_FIXED;
+    }
+
+    if(m_ui->defaultLayer->isEnabled() && m_ui->defaultLayer->isChecked()) {
+        c.changes |= CHANGE_DEFAULT;
+        c.defaultLayer = true;
+    }
+
+    if(c.changes != CHANGE_NOTHING) {
+        emit propertiesChanged(c);
+    }
+}
+
+void LayerProperties::applyLayerDataToUi()
+{
+    m_ui->title->setText(m_layerData.title);
+    m_ui->opacitySpinner->setValue(layerDataOpacity());
+    m_ui->visible->setChecked(!m_layerData.hidden);
+    m_ui->fixed->setChecked(m_layerData.fixed);
+    m_ui->defaultLayer->setChecked(m_layerData.defaultLayer);
+    m_ui->defaultLayer->setEnabled(!m_layerData.defaultLayer);
+    int blendModeIndex = searchBlendModeIndex(m_layerData.blend);
+    if(blendModeIndex == -1) {
+        // Apparently we don't know this blend mode, probably because
+        // this client is outdated. Disable the control to avoid damage.
+        m_ui->blendMode->setCurrentIndex(-1);
+        m_ui->blendMode->setEnabled(false);
+    } else {
+        m_ui->blendMode->setCurrentIndex(blendModeIndex);
+        m_ui->blendMode->setEnabled(true);
+    }
+}
+
+int LayerProperties::layerDataOpacity()
+{
+    return qRound(m_layerData.opacity * 100.0f);
+}
+
+int LayerProperties::searchBlendModeIndex(paintcore::BlendMode::Mode mode)
+{
+    int blendModeCount = m_ui->blendMode->count();
+    for(int i = 0; i < blendModeCount; ++i) {
+        if(m_ui->blendMode->itemData(i).toInt() == mode) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+}

--- a/src/desktop/dialogs/layerproperties.h
+++ b/src/desktop/dialogs/layerproperties.h
@@ -1,0 +1,89 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2007-2021 Calle Laakkonen
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LAYERPROPERTIES_H
+#define LAYERPROPERTIES_H
+
+#include <qobjectdefs.h>
+#include <qdialog.h>
+#include "core/blendmodes.h"
+
+class Ui_LayerProperties;
+
+namespace canvas {
+    class CanvasModel;
+}
+
+namespace dialogs {
+
+class LayerProperties : public QDialog
+{
+Q_OBJECT
+public:
+    struct LayerData {
+        int id;
+        QString title;
+        float opacity;
+        paintcore::BlendMode::Mode blend;
+        bool hidden;
+        bool fixed;
+        bool defaultLayer;
+    };
+
+    enum ChangeFlag {
+        CHANGE_NOTHING = 0,
+        CHANGE_TITLE = 1 << 0,
+        CHANGE_OPACITY = 1 << 1,
+        CHANGE_BLEND = 1 << 2,
+        CHANGE_HIDDEN = 1 << 3,
+        CHANGE_FIXED = 1 << 4,
+        CHANGE_DEFAULT = 1 << 5,
+    };
+
+    struct ChangedLayerData : public LayerData {
+        unsigned int changes;
+    };
+
+	explicit LayerProperties(QWidget *parent = nullptr);
+
+    void setCanvas(canvas::CanvasModel *canvas);
+    void setLayerData(const LayerData &data);
+
+signals:
+    void propertiesChanged(const ChangedLayerData &c);
+
+protected:
+    virtual void showEvent(QShowEvent *event) override;
+
+private slots:
+    void emitChanges();
+
+private:
+    void applyLayerDataToUi();
+    int layerDataOpacity();
+    int searchBlendModeIndex(paintcore::BlendMode::Mode mode);
+
+    Ui_LayerProperties *m_ui;
+    canvas::CanvasModel *m_canvas;
+    LayerData m_layerData;
+};
+
+}
+
+#endif

--- a/src/desktop/docks/layerlistdelegate.cpp
+++ b/src/desktop/docks/layerlistdelegate.cpp
@@ -132,15 +132,6 @@ void LayerListDelegate::updateEditorGeometry(QWidget *editor, const QStyleOption
 	editor->setGeometry(option.rect.adjusted(btnwidth, 0, -btnwidth, 0));
 }
 
-void LayerListDelegate::setModelData(QWidget *editor, QAbstractItemModel *, const QModelIndex& index) const
-{
-	const canvas::LayerListItem &layer = index.data().value<canvas::LayerListItem>();
-	QString newtitle = static_cast<QLineEdit*>(editor)->text();
-	if(layer.title != newtitle) {
-		emit const_cast<LayerListDelegate*>(this)->layerCommand(protocol::MessagePtr(new protocol::LayerRetitle(0, layer.id, newtitle)));
-	}
-}
-
 void LayerListDelegate::drawOpacityGlyph(const QRectF& rect, QPainter *painter, float value, bool hidden, bool censored) const
 {
 	const QRect r {

--- a/src/desktop/docks/layerlistdelegate.cpp
+++ b/src/desktop/docks/layerlistdelegate.cpp
@@ -89,7 +89,8 @@ void LayerListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
 
 bool LayerListDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
-	if(event->type() == QEvent::MouseButtonPress) {
+	QEvent::Type type = event->type();
+	if(type == QEvent::MouseButtonPress) {
 		const canvas::LayerListItem &layer = index.data().value<canvas::LayerListItem>();
 		const QMouseEvent *me = static_cast<QMouseEvent*>(event);
 
@@ -99,6 +100,14 @@ bool LayerListDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, co
 				emit toggleVisibility(layer.id, layer.hidden);
 				return true;
 			}
+		}
+	}
+
+	if(type == QEvent::MouseButtonDblClick) {
+		const QMouseEvent *me = static_cast<QMouseEvent*>(event);
+		if(me->button() == Qt::LeftButton) {
+			emit editProperties(index);
+			return true;
 		}
 	}
 

--- a/src/desktop/docks/layerlistdelegate.h
+++ b/src/desktop/docks/layerlistdelegate.h
@@ -52,6 +52,7 @@ public:
 
 signals:
 	void toggleVisibility(int layerId, bool visible);
+	void editProperties(QModelIndex index);
 	void layerCommand(protocol::MessagePtr msg);
 
 private:

--- a/src/desktop/docks/layerlistdelegate.h
+++ b/src/desktop/docks/layerlistdelegate.h
@@ -45,7 +45,6 @@ public:
 			const QModelIndex & index ) const;
 
 	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem & option, const QModelIndex & index ) const;
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex& index) const;
 	bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index);
 
 	void setShowNumbers(bool show);
@@ -53,7 +52,6 @@ public:
 signals:
 	void toggleVisibility(int layerId, bool visible);
 	void editProperties(QModelIndex index);
-	void layerCommand(protocol::MessagePtr msg);
 
 private:
 	void drawOpacityGlyph(const QRectF& rect, QPainter *painter, float value, bool hidden, bool censored) const;

--- a/src/desktop/docks/layerlistdock.cpp
+++ b/src/desktop/docks/layerlistdock.cpp
@@ -112,10 +112,6 @@ LayerList::LayerList(QWidget *parent)
 
 	// Custom layer list item delegate
 	LayerListDelegate *del = new LayerListDelegate(this);
-	connect(del, &LayerListDelegate::layerCommand, [this](protocol::MessagePtr msg) {
-		msg->setContextId(m_canvas->localUserId());
-		emit layerCommand(msg);
-	});
 	connect(del, &LayerListDelegate::toggleVisibility, this, &LayerList::setLayerVisibility);
 	connect(del, &LayerListDelegate::editProperties, this, &LayerList::showPropertiesOfIndex);
 	m_ui->layerlist->setItemDelegate(del);

--- a/src/desktop/docks/layerlistdock.h
+++ b/src/desktop/docks/layerlistdock.h
@@ -20,6 +20,7 @@
 #define LAYERLISTDOCK_H
 
 #include "canvas/features.h"
+#include "dialogs/layerproperties.h"
 
 #include <QDockWidget>
 
@@ -85,7 +86,8 @@ private slots:
 	void deleteSelected();
 	void setSelectedDefault();
 	void mergeSelected();
-	void renameSelected();
+	void showPropertiesOfSelected();
+	void showPropertiesOfIndex(QModelIndex index);
 	void opacityAdjusted();
 	void blendModeChanged();
 	void hideSelected();
@@ -101,6 +103,8 @@ private slots:
 
 	void sendOpacityUpdate();
 
+	void emitPropertyChangeCommands(const dialogs::LayerProperties::ChangedLayerData &c);
+
 private:
 	void updateLockedControls();
 	bool canMergeCurrent() const;
@@ -112,6 +116,7 @@ private:
 	int m_selectedId;
 	int m_lastSelectedRow;
 	bool m_noupdate;
+	dialogs::LayerProperties *m_layerProperties;
 	LayerAclMenu *m_aclmenu;
 	QMenu *m_layermenu;
 
@@ -123,7 +128,7 @@ private:
 	QAction *m_menuInsertAction;
 	QAction *m_menuSeparator;
 	QAction *m_menuHideAction;
-	QAction *m_menuRenameAction;
+	QAction *m_menuPropertiesAction;
 	QAction *m_menuDefaultAction;
 	QAction *m_menuFixedAction;
 

--- a/src/desktop/ui/layerbox.ui
+++ b/src/desktop/ui/layerbox.ui
@@ -107,6 +107,9 @@
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
      </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/desktop/ui/layerproperties.ui
+++ b/src/desktop/ui/layerproperties.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LayerProperties</class>
+ <widget class="QWidget" name="LayerProperties">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>298</width>
+    <height>222</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Layer Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <property name="horizontalSpacing">
+      <number>3</number>
+     </property>
+     <property name="verticalSpacing">
+      <number>5</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="titleLabel">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="title"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="opacityLabel">
+       <property name="text">
+        <string>Opacity:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QSlider" name="opacitySlider">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="opacitySpinner">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="blendModeLabel">
+       <property name="text">
+        <string>Blend Mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="blendMode"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="visible">
+     <property name="text">
+      <string>Visible</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="fixed">
+     <property name="text">
+      <string>Fixed</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="defaultLayer">
+     <property name="text">
+      <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>opacitySlider</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>opacitySpinner</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>154</x>
+     <y>77</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>259</x>
+     <y>77</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>opacitySpinner</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>opacitySlider</receiver>
+   <slot>setValue(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>259</x>
+     <y>77</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>154</x>
+     <y>77</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Krita, GIMP et cetera also have a dialog like this, to have all the information there to edit at once.

The opacity slider also has a spinner in this view, to allow setting a precise value and not having to twiddle slider positions until they match up between different layers.

This replaces the in-line layer title editing. Together with #971, this finally fixes #593, since it's the in-line edit control that's causing the problems. Moving it to a separate dialog removes the issue altogether. The dialog is set up so that the amount of user input for renaming a layer remains the same: double-click, type a new name and hit return.

I guess it would be nice to have the ACL settings here too, but since I only ever draw with friends in free-for-all sessions, I neither use that stuff nor know how it works. The existing menu still works fine though.

Showing it off:

https://user-images.githubusercontent.com/13625824/124358257-c9a40a80-dc1f-11eb-956b-05bcae59961a.mp4

