### PR TITLE
Fix compiler warnings from Qt, KDNSSD and new g++ smartness

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,10 @@ endif()
 
 if(KF5DNSSD_FOUND)
 	add_definitions(-DHAVE_DNSSD)
+	# KF5DNSSD 8.84.0 moves a bunch of headers to a different place.
+	if("${KF5DNSSD_VERSION}" VERSION_LESS "5.84.0")
+		add_definitions(-DHAVE_DNSSD_BEFORE_5_84_0)
+	endif()
 endif()
 
 add_subdirectory(libshared)

--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -120,8 +120,12 @@ if(LIBMINIUPNPC_FOUND)
 	add_definitions(-DHAVE_UPNP)
 endif()
 
-if(KF5DNSSD_FOUND) 
+if(KF5DNSSD_FOUND)
 	add_definitions(-DHAVE_DNSSD)
+	# KF5DNSSD 8.84.0 moves a bunch of headers to a different place.
+	if("${KF5DNSSD_VERSION}" VERSION_LESS "5.84.0")
+		add_definitions(-DHAVE_DNSSD_BEFORE_5_84_0)
+	endif()
 endif()
 
 if(LIBVPX_FOUND)

--- a/src/libclient/core/tile.h
+++ b/src/libclient/core/tile.h
@@ -45,7 +45,14 @@ struct TileData : public QSharedData {
 	TileData(const TileData &td);
 	~TileData();
 
-	static int globalCount() { return _count.load() ; }
+	static int globalCount()
+	{
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+		return _count.load(); // deprecated since Qt 5.14
+#else
+		return _count.loadRelaxed();
+#endif
+	}
 	static float megabytesUsed() { return globalCount() * sizeof(pixels) / float(1024*1024); }
 private:
 	static QAtomicInt _count;

--- a/src/libclient/utils/colorscheme.cpp
+++ b/src/libclient/utils/colorscheme.cpp
@@ -54,9 +54,9 @@ QPalette loadFromFile(const QString &filename)
 
 	QSettings settings(filename, QSettings::IniFormat);
 
-	for(const auto group : GROUPS) {
+	for(const auto &group : GROUPS) {
 		settings.beginGroup(group.second);
-		for(const auto role : ROLES) {
+		for(const auto &role : ROLES) {
 			palette.setColor(group.first, role.first, QColor(settings.value(role.second).toString()));
 		}
 		settings.endGroup();
@@ -68,9 +68,9 @@ bool saveToFile(const QString &filename, const QPalette &palette)
 {
 	QSettings settings(filename, QSettings::IniFormat);
 
-	for(const auto group : GROUPS) {
+	for(const auto &group : GROUPS) {
 		settings.beginGroup(group.second);
-		for(const auto role : ROLES) {
+		for(const auto &role : ROLES) {
 			settings.setValue(role.second, palette.color(group.first, role.first).name());
 		}
 		settings.endGroup();

--- a/src/libclient/utils/palette.cpp
+++ b/src/libclient/utils/palette.cpp
@@ -130,7 +130,7 @@ bool Palette::exportPalette(const QString &filename, QString *errorString)
 		out << "Name: " << _name << "\n";
 		out << "Columns: " << _columns << "\n";
 		out << "#\n";
-		for(const PaletteColor c : _colors) {
+		for(const PaletteColor &c : _colors) {
 			out << c.color.red() << ' ' << c.color.green() << ' ' << c.color.blue() << '\t' << c.name << '\n';
 		}
 		return true;

--- a/src/libshared/listings/zeroconfannouncement.cpp
+++ b/src/libshared/listings/zeroconfannouncement.cpp
@@ -20,7 +20,11 @@
 #include "zeroconfannouncement.h"
 #include "../net/protover.h"
 
-#include <KDNSSD/DNSSD/PublicService>
+#ifdef HAVE_DNSSD_BEFORE_5_84_0
+#	include <KDNSSD/DNSSD/PublicService>
+#else
+#	include <KDNSSD/PublicService>
+#endif
 #include <QDateTime>
 
 ZeroConfAnnouncement::ZeroConfAnnouncement(QObject *parent)

--- a/src/libshared/listings/zeroconfdiscovery.cpp
+++ b/src/libshared/listings/zeroconfdiscovery.cpp
@@ -20,7 +20,11 @@
 #include "zeroconfdiscovery.h"
 
 #include <QUrl>
-#include <KDNSSD/DNSSD/ServiceBrowser>
+#ifdef HAVE_DNSSD_BEFORE_5_84_0
+#	include <KDNSSD/DNSSD/ServiceBrowser>
+#else
+#	include <KDNSSD/ServiceBrowser>
+#endif
 
 ZeroconfDiscovery::ZeroconfDiscovery(QObject *parent)
 	: QObject(parent), m_browser(nullptr)

--- a/src/libshared/listings/zeroconfdiscovery.h
+++ b/src/libshared/listings/zeroconfdiscovery.h
@@ -22,7 +22,11 @@
 #include "announcementapi.h"
 
 #include <QVector>
-#include <KDNSSD/DNSSD/RemoteService>
+#ifdef HAVE_DNSSD_BEFORE_5_84_0
+#	include <KDNSSD/DNSSD/RemoteService>
+#else
+#	include <KDNSSD/RemoteService>
+#endif
 
 namespace KDNSSD {
 	class ServiceBrowser;

--- a/src/libshared/net/message.cpp
+++ b/src/libshared/net/message.cpp
@@ -156,7 +156,7 @@ QString Message::toString() const
 			i.next();
 			if(i.value().contains(space)) {
 				QStringList lines = i.value().split('\n');
-				for(const QString line : lines) {
+				for(const QString &line : lines) {
 					str += "\n\t";
 					str += i.key();
 					str += "=";

--- a/src/libshared/net/messagequeue.cpp
+++ b/src/libshared/net/messagequeue.cpp
@@ -166,7 +166,7 @@ void MessageQueue::sendPing()
 int MessageQueue::uploadQueueBytes() const
 {
 	int total = m_socket->bytesToWrite() + m_sendbuflen - m_sentbytes;
-	for(const MessagePtr msg : m_outbox)
+	for(const MessagePtr &msg : m_outbox)
 		total += msg->length();
 	return total;
 }

--- a/src/libshared/net/messagequeue.cpp
+++ b/src/libshared/net/messagequeue.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #ifndef NDEBUG
+#include <QRandomGenerator>
 #include <QThread>
 #endif
 
@@ -294,7 +295,7 @@ void MessageQueue::writeData() {
 #ifndef NDEBUG
 			// Debugging tool: simulate bad network connections by sleeping at odd times
 			if(m_randomlag>0) {
-				QThread::msleep(qrand() % m_randomlag);
+				QThread::msleep(QRandomGenerator::global()->generate() % m_randomlag);
 			}
 #endif
 

--- a/src/thinsrv/headless/configfile.cpp
+++ b/src/thinsrv/headless/configfile.cpp
@@ -167,7 +167,7 @@ bool ConfigFile::isAddressBanned(const QHostAddress &addr) const
 	if(isModified())
 		reloadFile();
 
-	for(const QPair<QHostAddress,int> ipban : m_banlist) {
+	for(const QPair<QHostAddress,int> &ipban : m_banlist) {
 		QHostAddress subnet = ipban.first;
 		int mask = ipban.second;
 


### PR DESCRIPTION
* Replaces deprecated `QAtomicInteger::load` with `QAtomicInteger::loadRelaxed` when using Qt >= 5.14.
* Includes different headers when using KDNSSD >= 5.84.0, since they got moved and the old locations deprecated.
* Replaces deprecated `qrand()` with `QRandomGenerator::global()->generate()`.
* Adds missing `&` to various for loop iterator variables, because g++ has started warning about those being pointless copies now.

Remaining warnings are just from mkvmuxer, which is an external library, and `QJsonDocument::fromBinaryData`, which is only there for compatibility.