### PR TITLE
Add missing i8n/drawpile_pt.ts to libclient

### DIFF
--- a/src/libclient/CMakeLists.txt
+++ b/src/libclient/CMakeLists.txt
@@ -131,6 +131,7 @@ if( Qt5LinguistTools_FOUND)
 		i18n/drawpile_uk.ts
 		i18n/drawpile_it.ts
 		i18n/drawpile_fr.ts
+		i18n/drawpile_pt.ts
 	)
 
 	qt5_add_translation(QM_TRANSLATIONS ${TRANSLATIONS})


### PR DESCRIPTION
It causes the Windows build to fail since d15772abd07ddc05750162b528e591ab071c465c.