### PR TITLE
brushPalette: prevent deleting Default folder, preventing crashses when no folders exist and using certain actions

### DIFF
--- a/src/desktop/docks/brushpalettedock.cpp
+++ b/src/desktop/docks/brushpalettedock.cpp
@@ -100,6 +100,12 @@ BrushPalette::BrushPalette(QWidget *parent)
 	auto *addFolderAction = hamburgerMenu->addAction("New Folder");
 	auto *deleteFolderAction = hamburgerMenu->addAction("Delete Folder");
 
+	// Default folder cannot be deleted
+	deleteFolderAction->setEnabled(false);
+	connect(d->ui.folder, QOverload<int>::of(&QComboBox::currentIndexChanged), deleteFolderAction, [=](int index) {
+		deleteFolderAction->setEnabled(index != 0);
+	});
+
 	d->ui.menuButton->setMenu(hamburgerMenu);
 
 	d->ui.brushPaletteView->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -134,7 +140,6 @@ BrushPalette::BrushPalette(QWidget *parent)
 			d->presets->moveBrush(idx, targetFolder);
 		}
 	});
-
 
 	connect(addBrushAction, &QAction::triggered, this, &BrushPalette::addBrush);
 	connect(overwriteBrushAction, &QAction::triggered, this, &BrushPalette::overwriteBrush);
@@ -205,7 +210,12 @@ void BrushPalette::addFolder()
 
 void BrushPalette::deleteFolder()
 {
-	const auto idx = d->presets->index(d->ui.folder->currentIndex());
+	const auto index = d->ui.folder->currentIndex();
+	if(index == 0){
+		qWarning("Cannot delete Default folder");
+		return;
+	}
+	const auto idx = d->presets->index(index);
 	const int brushCount = d->presets->rowCount(idx);
 	if(brushCount > 0) {
 		const auto btn = QMessageBox::question(


### PR DESCRIPTION
When deleting all folders in brush presets, the addBrush, and deleteFolder menu actions will cause drawpile to crash
This is adds a few checks, along with qWarning when using these actions with no folder.

Just saw the comment `// The first folder is always the built-in "Default" folder` so i assume that that folder should not be deleted and will add some checks, and such for that case

---
- Old

Before merging I want to ask, what would the best choice be to handle this situation

1. disable invalid menu options
2. hide invalid menu options (only addFolder  would show in context menu)
3. prevent last folder from being deleted (Alternatively, prevent Default folder from being deleted)

I have 1 ready to push, and 2 requires only a small edit.

Considering how you cannot rename default, and if you delete it and create a new one, (new folder) you cant rename that,
it also matches behavior from the input presets, so 3 seems best i guess