### PR TITLE
Make classic brush lookup tables consistent

### DIFF
--- a/src/libclient/brushes/classicbrushpainter.cpp
+++ b/src/libclient/brushes/classicbrushpainter.cpp
@@ -57,7 +57,7 @@ static LUT cachedGimpStyleBrushLUT(float hardness)
 	const int h = hardness * 100;
 	Q_ASSERT(h>=0 && h<=100);
 	if(!LUT_CACHE.contains(h))
-		LUT_CACHE.insert(h, new LUT(makeGimpStyleBrushLUT(hardness)));
+		LUT_CACHE.insert(h, new LUT(makeGimpStyleBrushLUT(h / 100.0)));
 
 	return *LUT_CACHE[h];
 }


### PR DESCRIPTION
There's 256 different hardness values, but only 101 lookup tables for them. Before this commit, the lookup table was calculated using the hardness value gotten from calculating `hardness / 255.0`, which was then assigned to the lookup table at index `int(hardness / 255.0 * 100.0)`.

That's inconsistent however. For example, hardnesses 227, 228 and 229 all get assigned to index 89, but calculate slightly different values for the lookup table. That means, depending on which order you draw dabs and how the cache behaves, you get different results.

This commit now always calculates the hardness according to the index of the lookup table, so index 89 will always contain the value for hardness 0.89 without any jitter.