### PR TITLE
Make layer resize color sampling consistent

### DIFF
--- a/src/libclient/core/layer.cpp
+++ b/src/libclient/core/layer.cpp
@@ -86,7 +86,11 @@ QColor _sampleEdgeColors(const Layer *layer, bool top, bool right, bool bottom, 
 	QHashIterator<QRgb, int> i(colorfreq);
 	while(i.hasNext()) {
 		i.next();
-		if(i.value() > freq) {
+		int value = i.value();
+		// In the unlikely case of two colors being equally frequent, pick the
+		// smaller one just for consistency. Otherwise the random ordering of
+		// QHash might lead to users getting different results from this.
+		if(value > freq || (value == freq && i.key() < color)) {
 			freq = i.value();
 			color = i.key();
 		}


### PR DESCRIPTION
When resizing a layer, Drawpile tries to guess a color to fill the background with. For that, it uses a hash table to keep track of the  fequency of color samples from the edges of the canvas and grabs the color that has the highest frequency at the end.

However, in the (exceedingly theoretical) case where two colors have the exact same frequency, Drawpile will effectively pick whichever color is the first one it finds in the hash table. QHash has no defined order, so it picks at random. This could lead to inconsistent colors being chosen for different users or when playing back a recording if the hash table ends up in a different order.

This commit adds a tie-breaker for those cases: it uses the color with the smaller numerical value. That way, the resulting color will always be consistent.