### PR TITLE
Layer Group Improvements

### DIFF
--- a/src/desktop/dialogs/layerproperties.cpp
+++ b/src/desktop/dialogs/layerproperties.cpp
@@ -77,8 +77,8 @@ void LayerProperties::setLayerItem(const canvas::LayerListItem &item, const QStr
 		m_ui->blendMode->setEnabled(true);
 	}
 
-	m_ui->isolated->setChecked(!item.group || item.isolated);
-	m_ui->isolated->setVisible(item.group);
+	m_ui->passThrough->setChecked(!item.group || !item.isolated);
+	m_ui->passThrough->setVisible(item.group);
 	m_ui->createdBy->setText(creator);
 }
 
@@ -88,7 +88,7 @@ void LayerProperties::setControlsEnabled(bool enabled) {
 		m_ui->opacitySlider,
 		m_ui->opacitySpinner,
 		m_ui->blendMode,
-		m_ui->isolated,
+		m_ui->passThrough,
 		m_ui->censored
 	};
 	for(unsigned int i=0;i<sizeof(w)/sizeof(*w);++i)
@@ -124,7 +124,7 @@ void LayerProperties::emitChanges()
 	const int oldOpacity = qRound(m_item.opacity * 100.0);
 	const rustpile::Blendmode newBlendmode = static_cast<rustpile::Blendmode>(m_ui->blendMode->currentData().toInt());
 	const bool censored = m_ui->censored->isChecked();
-	const bool isolated = m_ui->isolated->isChecked();
+	const bool isolated = !m_ui->passThrough->isChecked();
 
 	if(
 		m_ui->opacitySpinner->value() != oldOpacity ||

--- a/src/desktop/docks/layerlistdock.cpp
+++ b/src/desktop/docks/layerlistdock.cpp
@@ -71,6 +71,7 @@ LayerList::LayerList(QWidget *parent)
 	m_view->viewport()->setAcceptDrops(true);
 	m_view->setEnabled(false);
 	m_view->setSelectionMode(QAbstractItemView::SingleSelection);
+	m_view->setEditTriggers(QAbstractItemView::NoEditTriggers);
 
 	// Layer ACL menu
 	m_aclmenu = new LayerAclMenu(this);
@@ -190,8 +191,6 @@ void LayerList::updateLockedControls()
 		m_deleteLayerAction->setEnabled(enabled);
 		m_mergeLayerAction->setEnabled(enabled && canMergeCurrent());
 	}
-
-	m_view->setEditTriggers(enabled ? QAbstractItemView::DoubleClicked : QAbstractItemView::NoEditTriggers);
 }
 
 void LayerList::selectLayer(int id)

--- a/src/desktop/docks/layerlistdock.cpp
+++ b/src/desktop/docks/layerlistdock.cpp
@@ -109,7 +109,7 @@ void LayerList::setCanvas(canvas::CanvasModel *canvas)
 	updateLockedControls();
 }
 
-void LayerList::setLayerEditActions(QAction *addLayer, QAction *addGroup, QAction *duplicate, QAction *merge, QAction *del)
+void LayerList::setLayerEditActions(QAction *addLayer, QAction *addGroup, QAction *duplicate, QAction *merge, QAction *properties, QAction *del)
 {
 	Q_ASSERT(addLayer);
 	Q_ASSERT(addGroup);
@@ -120,6 +120,7 @@ void LayerList::setLayerEditActions(QAction *addLayer, QAction *addGroup, QActio
 	m_addGroupAction = addGroup;
 	m_duplicateLayerAction = duplicate;
 	m_mergeLayerAction = merge;
+	m_propertiesAction = properties;
 	m_deleteLayerAction = del;
 
 	// Add the actions to the header bar
@@ -142,6 +143,10 @@ void LayerList::setLayerEditActions(QAction *addLayer, QAction *addGroup, QActio
 	mergeLayerButton->setDefaultAction(m_mergeLayerAction);
 	titlebar->addCustomWidget(mergeLayerButton);
 
+	auto *propertiesButton = new widgets::GroupedToolButton(widgets::GroupedToolButton::GroupCenter, titlebar);
+	propertiesButton->setDefaultAction(m_propertiesAction);
+	titlebar->addCustomWidget(propertiesButton);
+
 	auto *deleteLayerButton = new widgets::GroupedToolButton(widgets::GroupedToolButton::GroupRight, titlebar);
 	deleteLayerButton->setDefaultAction(m_deleteLayerAction);
 	titlebar->addCustomWidget(deleteLayerButton);
@@ -153,6 +158,7 @@ void LayerList::setLayerEditActions(QAction *addLayer, QAction *addGroup, QActio
 	connect(m_addGroupAction, &QAction::triggered, this, &LayerList::addGroup);
 	connect(m_duplicateLayerAction, &QAction::triggered, this, &LayerList::duplicateLayer);
 	connect(m_mergeLayerAction, &QAction::triggered, this, &LayerList::mergeSelected);
+	connect(m_propertiesAction, &QAction::triggered, this, &LayerList::showPropertiesOfSelected);
 	connect(m_deleteLayerAction, &QAction::triggered, this, &LayerList::deleteSelected);
 
 	updateLockedControls();
@@ -188,6 +194,7 @@ void LayerList::updateLockedControls()
 	m_lockButton->setEnabled(enabled);
 	if(hasEditActions) {
 		m_duplicateLayerAction->setEnabled(enabled);
+		m_propertiesAction->setEnabled(enabled);
 		m_deleteLayerAction->setEnabled(enabled);
 		m_mergeLayerAction->setEnabled(enabled && canMergeCurrent());
 	}

--- a/src/desktop/docks/layerlistdock.h
+++ b/src/desktop/docks/layerlistdock.h
@@ -56,7 +56,7 @@ public:
 	void setCanvas(canvas::CanvasModel *canvas);
 
 	//! These actions are shown in a menu outside this dock
-	void setLayerEditActions(QAction *addLayer, QAction *addGroup, QAction *duplicate, QAction *merge, QAction *del);
+	void setLayerEditActions(QAction *addLayer, QAction *addGroup, QAction *duplicate, QAction *merge, QAction *properties, QAction *del);
 
 	/**
 	 * Is the currently selected layer locked for editing?
@@ -128,6 +128,7 @@ private:
 	QAction *m_addGroupAction;
 	QAction *m_duplicateLayerAction;
 	QAction *m_mergeLayerAction;
+	QAction *m_propertiesAction;
 	QAction *m_deleteLayerAction;
 };
 

--- a/src/desktop/docks/layerlistdock.h
+++ b/src/desktop/docks/layerlistdock.h
@@ -88,7 +88,9 @@ private slots:
 	void deleteSelected();
 	void mergeSelected();
 
+	void showPropertiesOfSelected();
 	void showPropertiesOfIndex(QModelIndex index);
+	void showContextMenu(const QPoint &pos);
 	void censorSelected(bool censor);
 	void setLayerVisibility(int layerId, bool visible);
 	void changeLayerAcl(bool lock, canvas::Tier tier, QVector<uint8_t> exclusive);
@@ -119,6 +121,7 @@ private:
 
 	bool m_noupdate;
 
+	QMenu *m_contextMenu;
 	LayerAclMenu *m_aclmenu;
 
 	widgets::GroupedToolButton *m_lockButton;

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -2630,9 +2630,10 @@ void MainWindow::setupActions()
 	QAction *groupAdd = makeAction("groupadd", tr("New Group")).icon("folder-new");
 	QAction *layerDupe = makeAction("layerdupe", tr("Duplicate Layer")).icon("edit-copy");
 	QAction *layerMerge = makeAction("layermerge", tr("Merge with Layer Below")).icon("arrow-down-double");
+	QAction *layerProperties = makeAction("layerproperties", tr("Properties...")).icon("configure");
 	QAction *layerDelete = makeAction("layerdelete", tr("Delete Layer")).icon("list-remove");
 
-	m_dockLayers->setLayerEditActions(layerAdd, groupAdd, layerDupe, layerMerge, layerDelete);
+	m_dockLayers->setLayerEditActions(layerAdd, groupAdd, layerDupe, layerMerge, layerProperties, layerDelete);
 
 	QAction *layerSolo = makeAction("layerviewsolo", tr("Solo")).shortcut("Shift+Home").checkable();
 	QAction *layerFrame = makeAction("layerviewframe", tr("Frame")).shortcut("Home").checkable();

--- a/src/desktop/ui/layerproperties.ui
+++ b/src/desktop/ui/layerproperties.ui
@@ -69,9 +69,9 @@
     <widget class="QComboBox" name="blendMode"/>
    </item>
    <item row="6" column="1">
-    <widget class="QCheckBox" name="isolated">
+    <widget class="QCheckBox" name="passThrough">
      <property name="text">
-      <string>Isolated group</string>
+      <string>Pass through</string>
      </property>
     </widget>
    </item>
@@ -216,7 +216,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>isolated</sender>
+   <sender>passThrough</sender>
    <signal>toggled(bool)</signal>
    <receiver>blendMode</receiver>
    <slot>setEnabled(bool)</slot>

--- a/src/dpcore/src/paint/rasterop.rs
+++ b/src/dpcore/src/paint/rasterop.rs
@@ -22,8 +22,11 @@
 
 use super::color::*;
 use super::Blendmode;
+#[cfg(debug_assertions)]
+use tracing::warn;
 
 pub fn pixel_blend(base: &mut [Pixel], over: &[Pixel], opacity: u8, mode: Blendmode) {
+    #[allow(unreachable_patterns)]
     match mode {
         Blendmode::Normal => alpha_pixel_blend(base, over, opacity),
         Blendmode::Erase => alpha_pixel_erase(base, over, opacity),
@@ -40,10 +43,15 @@ pub fn pixel_blend(base: &mut [Pixel], over: &[Pixel], opacity: u8, mode: Blendm
         Blendmode::ColorErase => pixel_color_erase(base, over, opacity),
         Blendmode::Screen => pixel_composite(comp_op_screen, base, over, opacity),
         Blendmode::Replace => pixel_replace(base, over, opacity),
+        _m => {
+            #[cfg(debug_assertions)]
+            warn!("Unknown pixel blend mode {:?}", _m);
+        }
     }
 }
 
 pub fn mask_blend(base: &mut [Pixel], color: Pixel, mask: &[u8], mode: Blendmode) {
+    #[allow(unreachable_patterns)]
     match mode {
         Blendmode::Normal => alpha_mask_blend(base, color, mask),
         Blendmode::Erase => alpha_mask_erase(base, mask),
@@ -59,7 +67,10 @@ pub fn mask_blend(base: &mut [Pixel], color: Pixel, mask: &[u8], mode: Blendmode
         Blendmode::Behind => alpha_mask_under(base, color, mask),
         Blendmode::Screen => mask_composite(comp_op_screen, base, color, mask),
         Blendmode::ColorErase => mask_color_erase(base, color, mask),
-        m => panic!("TODO unimplemented mask blend mode {:?}", m),
+        _m => {
+            #[cfg(debug_assertions)]
+            warn!("Unknown mask blend mode {:?}", _m);
+        }
     }
 }
 

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -108,7 +108,12 @@ static const BlendModeInfo BLEND_MODE[] = {
 		QT_TRANSLATE_NOOP("blendmode", "Add"),
 		Blendmode::Add,
 		UniversalMode
-	}
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Erase"),
+		Blendmode::Erase,
+		LayerMode
+	},
 };
 
 static const int BLEND_MODES = sizeof(BLEND_MODE)/sizeof(BlendModeInfo);

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -57,7 +57,7 @@ static const BlendModeInfo BLEND_MODE[] = {
 	{
 		QT_TRANSLATE_NOOP("blendmode", "Recolor"),
 		Blendmode::Recolor,
-		BrushMode
+		UniversalMode,
 	},
 	{
 		QT_TRANSLATE_NOOP("blendmode", "Behind"),


### PR DESCRIPTION
I've bundled several changes into one here, but if any of them need more discussion, I can split them off into separate PRs.

## Disable edit triggers on layer tree

Otherwise a double right-click triggers a faux-rename, which doesn't actually work. I think this was a leftover from before the layer properties dialog existed, which is the actual way to rename a layer.

## Add a "properties" layer action

So that you don't have to know the secret handshake of double-clicking on a layer to get at the properties dialog.

## Add a context menu to the layer tree

Since just doing nothing at all is really strange for both new and existing Drawpile users. The context menu simply has all the actions that are also available in the title bar.

## Change "isolated group" to "pass through"

Since that's what other programs call it. A pass-through group is a non-isolated group, so the checkbox is inverted.

## Allow Recolor blend mode for layers

Since with groups this now actually has a use: recoloring only the layers within the group.

## Allow Erase blend mode for layers

This also has a use with layer groups now, since you can erase stuff that's within the group.

## Don't panic! when dealing with unknown blend modes

Just print a warning in debug mode and don't do any blending. Otherwise that's a super easy way to ruin a session: send a dab with an invalid blend mode and then all clients will forever choke on it.

## Don't composite onto document background

The document background shouldn't be treated as if it actually existed, since that displays results very much unlike they would show up when exported as a flat image without the background. This can be seen very obviously with the Erase blend mode: I expect to see the checkerboard pattern behind the erased area, I don't want to erase the checkerboard itself. The same also applies to blend modes like Multiply: they shouldn't multiply the checkerboard, because when I export the file, there's nothing there to multiply either.

This also gets rid of the background tile cache, since that becomes superfluous due to this change.

Here's an example. Let's say I've made this amazing art piece with a transparent background, a Normal layer with a red stroke and a Multiply layer with a blue stroke: 
![image](https://user-images.githubusercontent.com/13625824/183252525-aef16c91-2ad0-4d7d-8680-e23f41144cae.png)

I go ahead and save it. Then I take a look at it aaand I can't see the blue stroke anymore: 
![image](https://user-images.githubusercontent.com/13625824/183252548-70bb6d43-a18a-4b47-a44a-ad260ce33359.png)

That's because Drawpile lied to me by compositing the Multiply layer onto the checkerboard background, which is incorrect. With this commit, the checkerboard pattern is not composited onto, it is simply placed behind the final image as it should be: 
![image](https://user-images.githubusercontent.com/13625824/183252724-f50a0d5c-b72c-4592-a41a-6c320f101501.png)

This is even more obvious with the (newly added) Erase layer mode: if I erase the background, I expect to see the checkerboard pattern behind it, not a black void.