### PR TITLE
More Blendmodes

### DIFF
--- a/src/dpcore/src/brush/mypaintbrushstate.rs
+++ b/src/dpcore/src/brush/mypaintbrushstate.rs
@@ -225,7 +225,7 @@ impl MyPaintBrushState {
         }
 
         let (h, s, v) = brush.color.as_hsv();
-        self.set_base_value(c::MyPaintBrushSetting_MYPAINT_BRUSH_SETTING_COLOR_H, h);
+        self.set_base_value(c::MyPaintBrushSetting_MYPAINT_BRUSH_SETTING_COLOR_H, h / 360.0);
         self.set_base_value(c::MyPaintBrushSetting_MYPAINT_BRUSH_SETTING_COLOR_S, s);
         self.set_base_value(c::MyPaintBrushSetting_MYPAINT_BRUSH_SETTING_COLOR_V, v);
 

--- a/src/dpcore/src/paint/blendmode.rs
+++ b/src/dpcore/src/paint/blendmode.rs
@@ -44,6 +44,7 @@ pub enum Blendmode {
     LuminosityShineSai,
     Overlay,
     HardLight,
+    SoftLight,
     Replace = 255,
 }
 
@@ -90,6 +91,7 @@ impl Blendmode {
             LuminosityShineSai => "krita:luminosity_sai",
             Overlay => "svg:overlay",
             HardLight => "svg:hard-light",
+            SoftLight => "svg:soft-light",
             Replace => "-dp-replace",
         }
     }
@@ -118,6 +120,7 @@ impl Blendmode {
             "krita:luminosity_sai" => LuminosityShineSai,
             "overlay" => Overlay,
             "hard-light" => HardLight,
+            "soft-light" => SoftLight,
             _ => {
                 return None;
             }

--- a/src/dpcore/src/paint/blendmode.rs
+++ b/src/dpcore/src/paint/blendmode.rs
@@ -45,6 +45,8 @@ pub enum Blendmode {
     Overlay,
     HardLight,
     SoftLight,
+    LinearBurn,
+    LinearLight,
     Replace = 255,
 }
 
@@ -92,6 +94,8 @@ impl Blendmode {
             Overlay => "svg:overlay",
             HardLight => "svg:hard-light",
             SoftLight => "svg:soft-light",
+            LinearBurn => "krita:linear_burn",
+            LinearLight => "krita:linear light",
             Replace => "-dp-replace",
         }
     }
@@ -121,6 +125,8 @@ impl Blendmode {
             "overlay" => Overlay,
             "hard-light" => HardLight,
             "soft-light" => SoftLight,
+            "krita:linear_burn" => LinearBurn,
+            "krita:linear light" => LinearLight,
             _ => {
                 return None;
             }

--- a/src/dpcore/src/paint/blendmode.rs
+++ b/src/dpcore/src/paint/blendmode.rs
@@ -41,6 +41,7 @@ pub enum Blendmode {
     ColorErase,
     Screen,
     NormalAndEraser,
+    LuminosityShineSai,
     Replace = 255,
 }
 
@@ -84,6 +85,7 @@ impl Blendmode {
             ColorErase => "-dp-cerase",
             Screen => "svg:screen",
             NormalAndEraser => "-dp-normal-and-eraser",
+            LuminosityShineSai => "krita:luminosity_sai",
             Replace => "-dp-replace",
         }
     }
@@ -109,6 +111,7 @@ impl Blendmode {
             "screen" => Screen,
             "-dp-replace" => Replace,
             "-dp-normal-and-eraser" => NormalAndEraser,
+            "krita:luminosity_sai" => LuminosityShineSai,
             _ => {
                 return None;
             }

--- a/src/dpcore/src/paint/blendmode.rs
+++ b/src/dpcore/src/paint/blendmode.rs
@@ -47,6 +47,10 @@ pub enum Blendmode {
     SoftLight,
     LinearBurn,
     LinearLight,
+    Hue,
+    Saturation,
+    Luminosity,
+    Color,
     Replace = 255,
 }
 
@@ -96,6 +100,10 @@ impl Blendmode {
             SoftLight => "svg:soft-light",
             LinearBurn => "krita:linear_burn",
             LinearLight => "krita:linear light",
+            Hue => "hue",
+            Saturation => "saturation",
+            Luminosity => "luminosity",
+            Color => "color",
             Replace => "-dp-replace",
         }
     }
@@ -127,6 +135,10 @@ impl Blendmode {
             "soft-light" => SoftLight,
             "krita:linear_burn" => LinearBurn,
             "krita:linear light" => LinearLight,
+            "hue" => Hue,
+            "saturation" => Saturation,
+            "luminosity" => Luminosity,
+            "color" => Color,
             _ => {
                 return None;
             }

--- a/src/dpcore/src/paint/blendmode.rs
+++ b/src/dpcore/src/paint/blendmode.rs
@@ -42,6 +42,8 @@ pub enum Blendmode {
     Screen,
     NormalAndEraser,
     LuminosityShineSai,
+    Overlay,
+    HardLight,
     Replace = 255,
 }
 
@@ -86,6 +88,8 @@ impl Blendmode {
             Screen => "svg:screen",
             NormalAndEraser => "-dp-normal-and-eraser",
             LuminosityShineSai => "krita:luminosity_sai",
+            Overlay => "svg:overlay",
+            HardLight => "svg:hard-light",
             Replace => "-dp-replace",
         }
     }
@@ -112,6 +116,8 @@ impl Blendmode {
             "-dp-replace" => Replace,
             "-dp-normal-and-eraser" => NormalAndEraser,
             "krita:luminosity_sai" => LuminosityShineSai,
+            "overlay" => Overlay,
+            "hard-light" => HardLight,
             _ => {
                 return None;
             }

--- a/src/dpcore/src/paint/color.rs
+++ b/src/dpcore/src/paint/color.rs
@@ -157,12 +157,20 @@ impl Color {
             | ((self.a * 255.0 + 0.5) as u32) << 24
     }
 
+    pub fn min_component(&self) -> f32 {
+        min_by(self.r, min_by(self.g, self.b, compare_floats), compare_floats)
+    }
+
+    pub fn max_component(&self) -> f32 {
+        max_by(self.r, max_by(self.g, self.b, compare_floats), compare_floats)
+    }
+
     pub fn as_hsv(&self) -> (f32, f32, f32) {
         let r = self.r;
         let g = self.g;
         let b = self.b;
-        let m = min_by(r, min_by(g, b, compare_floats), compare_floats);
-        let v = max_by(r, max_by(g, b, compare_floats), compare_floats);
+        let m = self.min_component();
+        let v = self.max_component();
         let d = v - m;
         if d == 0.0 {
             (0.0, 0.0, v)

--- a/src/dpcore/src/paint/color.rs
+++ b/src/dpcore/src/paint/color.rs
@@ -174,7 +174,7 @@ impl Color {
             } else {
                 (r - g) / d + 4.0
             } * 60.0;
-            let h = if raw_h < 0.0 { raw_h + 360.0 } else { raw_h } / 360.0;
+            let h = if raw_h < 0.0 { raw_h + 360.0 } else { raw_h };
             let s = d / v;
             (h, s, v)
         }

--- a/src/dpcore/src/paint/rasterop.rs
+++ b/src/dpcore/src/paint/rasterop.rs
@@ -51,23 +51,24 @@ pub fn pixel_blend(base: &mut [Pixel], over: &[Pixel], opacity: u8, mode: Blendm
 }
 
 pub fn mask_blend(base: &mut [Pixel], color: Pixel, mask: &[u8], mode: Blendmode, opacity: u8) {
+    let o = opacity as u32;
     #[allow(unreachable_patterns)]
     match mode {
-        Blendmode::Normal => alpha_mask_blend(base, color, mask, opacity as u32),
-        Blendmode::Erase => alpha_mask_erase(base, mask, opacity as u32),
-        Blendmode::Multiply => mask_composite(comp_op_multiply, base, color, mask, opacity as u32),
-        Blendmode::Divide => mask_composite(comp_op_divide, base, color, mask, opacity as u32),
-        Blendmode::Darken => mask_composite(comp_op_darken, base, color, mask, opacity as u32),
-        Blendmode::Lighten => mask_composite(comp_op_lighten, base, color, mask, opacity as u32),
-        Blendmode::Dodge => mask_composite(comp_op_dodge, base, color, mask, opacity as u32),
-        Blendmode::Burn => mask_composite(comp_op_burn, base, color, mask, opacity as u32),
-        Blendmode::Add => mask_composite(comp_op_add, base, color, mask, opacity as u32),
-        Blendmode::Subtract => mask_composite(comp_op_subtract, base, color, mask, opacity as u32),
-        Blendmode::Recolor => mask_composite(comp_op_recolor, base, color, mask, opacity as u32),
-        Blendmode::Behind => alpha_mask_under(base, color, mask, opacity as u32),
-        Blendmode::Screen => mask_composite(comp_op_screen, base, color, mask, opacity as u32),
-        Blendmode::ColorErase => mask_color_erase(base, color, mask, opacity as u32),
-        Blendmode::NormalAndEraser => alpha_mask_blend_erase(base, color, mask, opacity as u32),
+        Blendmode::Normal => alpha_mask_blend(base, color, mask, o),
+        Blendmode::Erase => alpha_mask_erase(base, mask, o),
+        Blendmode::Multiply => mask_composite(comp_op_multiply, base, color, mask, o),
+        Blendmode::Divide => mask_composite(comp_op_divide, base, color, mask, o),
+        Blendmode::Darken => mask_composite(comp_op_darken, base, color, mask, o),
+        Blendmode::Lighten => mask_composite(comp_op_lighten, base, color, mask, o),
+        Blendmode::Dodge => mask_composite(comp_op_dodge, base, color, mask, o),
+        Blendmode::Burn => mask_composite(comp_op_burn, base, color, mask, o),
+        Blendmode::Add => mask_composite(comp_op_add, base, color, mask, o),
+        Blendmode::Subtract => mask_composite(comp_op_subtract, base, color, mask, o),
+        Blendmode::Recolor => mask_composite(comp_op_recolor, base, color, mask, o),
+        Blendmode::Behind => alpha_mask_under(base, color, mask, o),
+        Blendmode::Screen => mask_composite(comp_op_screen, base, color, mask, o),
+        Blendmode::ColorErase => mask_color_erase(base, color, mask, o),
+        Blendmode::NormalAndEraser => alpha_mask_blend_erase(base, color, mask, o),
         _m => {
             #[cfg(debug_assertions)]
             warn!("Unknown mask blend mode {:?}", _m);

--- a/src/dpcore/src/paint/rasterop.rs
+++ b/src/dpcore/src/paint/rasterop.rs
@@ -45,6 +45,7 @@ pub fn pixel_blend(base: &mut [Pixel], over: &[Pixel], opacity: u8, mode: Blendm
         Blendmode::LuminosityShineSai => pixel_luminosity_shine_sai(base, over, opacity),
         Blendmode::Overlay => pixel_composite(comp_op_overlay, base, over, opacity),
         Blendmode::HardLight => pixel_composite(comp_op_hard_light, base, over, opacity),
+        Blendmode::SoftLight => pixel_composite(comp_op_soft_light, base, over, opacity),
         Blendmode::Replace => pixel_replace(base, over, opacity),
         _m => {
             #[cfg(debug_assertions)]
@@ -75,6 +76,7 @@ pub fn mask_blend(base: &mut [Pixel], color: Pixel, mask: &[u8], mode: Blendmode
         Blendmode::LuminosityShineSai => mask_luminosity_shine_sai(base, color, mask, o),
         Blendmode::Overlay => mask_composite(comp_op_overlay, base, color, mask, o),
         Blendmode::HardLight => mask_composite(comp_op_hard_light, base, color, mask, o),
+        Blendmode::SoftLight => mask_composite(comp_op_soft_light, base, color, mask, o),
         _m => {
             #[cfg(debug_assertions)]
             warn!("Unknown mask blend mode {:?}", _m);
@@ -109,6 +111,29 @@ fn u8_mult(a: u32, b: u32) -> u32 {
 fn u8_blend(a: i32, b: i32, alpha: i32) -> i32 {
     let c = (a - b) * alpha + (b << 8) - b + 0x80;
     ((c >> 8) + c) >> 8
+}
+
+// 8 bit square root lookup table. The values are floored, so the math is
+// floor(sqrt(i / 255.0) * 255.0) for i in 0 .. 255.
+const U8_SQRT_LOOKUP: [u32; 256] = [
+    0, 15, 22, 27, 31, 35, 39, 42, 45, 47, 50, 52, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 74, 76,
+    78, 79, 81, 82, 84, 85, 87, 88, 90, 91, 93, 94, 95, 97, 98, 99, 100, 102, 103, 104, 105, 107,
+    108, 109, 110, 111, 112, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
+    128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 141, 142, 143, 144, 145,
+    146, 147, 148, 148, 149, 150, 151, 152, 153, 153, 154, 155, 156, 157, 158, 158, 159, 160, 161,
+    162, 162, 163, 164, 165, 165, 166, 167, 168, 168, 169, 170, 171, 171, 172, 173, 174, 174, 175,
+    176, 177, 177, 178, 179, 179, 180, 181, 182, 182, 183, 184, 184, 185, 186, 186, 187, 188, 188,
+    189, 190, 190, 191, 192, 192, 193, 194, 194, 195, 196, 196, 197, 198, 198, 199, 200, 200, 201,
+    201, 202, 203, 203, 204, 205, 205, 206, 206, 207, 208, 208, 209, 210, 210, 211, 211, 212, 213,
+    213, 214, 214, 215, 216, 216, 217, 217, 218, 218, 219, 220, 220, 221, 221, 222, 222, 223, 224,
+    224, 225, 225, 226, 226, 227, 228, 228, 229, 229, 230, 230, 231, 231, 232, 233, 233, 234, 234,
+    235, 235, 236, 236, 237, 237, 238, 238, 239, 240, 240, 241, 241, 242, 242, 243, 243, 244, 244,
+    245, 245, 246, 246, 247, 247, 248, 248, 249, 249, 250, 250, 251, 251, 252, 252, 253, 253, 254,
+    255,
+];
+
+fn u8_sqrt(a: u32) -> u32 {
+    U8_SQRT_LOOKUP[a as usize]
 }
 
 /// Perform a premultiplied alpha blend operation on a slice of 32 bit ARGB pixels
@@ -389,6 +414,22 @@ fn comp_op_hard_light(a: u32, b: u32) -> u32 {
         comp_op_multiply(a, b2)
     } else {
         comp_op_screen(a, b2 - 255)
+    }
+}
+
+fn comp_op_soft_light(a: u32, b: u32) -> u32 {
+    let b2 = b * 2;
+    if b2 <= 255 {
+        a - u8_mult(u8_mult(255 - b2, a), 255 - a)
+    } else {
+        let a4 = a * 4;
+        let d = if a4 <= 255 {
+            let squared = u8_mult(a, a);
+            a4 + 16 * u8_mult(squared, a) - 12 * squared
+        } else {
+            u8_sqrt(a)
+        };
+        a + u8_mult(b2 - 255, d - a)
     }
 }
 

--- a/src/dpcore/src/paint/rasterop.rs
+++ b/src/dpcore/src/paint/rasterop.rs
@@ -46,6 +46,8 @@ pub fn pixel_blend(base: &mut [Pixel], over: &[Pixel], opacity: u8, mode: Blendm
         Blendmode::Overlay => pixel_composite(comp_op_overlay, base, over, opacity),
         Blendmode::HardLight => pixel_composite(comp_op_hard_light, base, over, opacity),
         Blendmode::SoftLight => pixel_composite(comp_op_soft_light, base, over, opacity),
+        Blendmode::LinearBurn => pixel_composite(comp_op_linear_burn, base, over, opacity),
+        Blendmode::LinearLight => pixel_composite(comp_op_linear_light, base, over, opacity),
         Blendmode::Replace => pixel_replace(base, over, opacity),
         _m => {
             #[cfg(debug_assertions)]
@@ -77,6 +79,8 @@ pub fn mask_blend(base: &mut [Pixel], color: Pixel, mask: &[u8], mode: Blendmode
         Blendmode::Overlay => mask_composite(comp_op_overlay, base, color, mask, o),
         Blendmode::HardLight => mask_composite(comp_op_hard_light, base, color, mask, o),
         Blendmode::SoftLight => mask_composite(comp_op_soft_light, base, color, mask, o),
+        Blendmode::LinearBurn => mask_composite(comp_op_linear_burn, base, color, mask, o),
+        Blendmode::LinearLight => mask_composite(comp_op_linear_light, base, color, mask, o),
         _m => {
             #[cfg(debug_assertions)]
             warn!("Unknown mask blend mode {:?}", _m);
@@ -459,6 +463,14 @@ fn comp_op_add(a: u32, b: u32) -> u32 {
 
 fn comp_op_subtract(a: u32, b: u32) -> u32 {
     0.max(a as i32 - b as i32) as u32
+}
+
+fn comp_op_linear_burn(a: u32, b: u32) -> u32 {
+    255.max(a + b) - 255
+}
+
+fn comp_op_linear_light(a: u32, b: u32) -> u32 {
+    ((a + 2 * b) as i32 - 255).clamp(0, 255) as u32
 }
 
 fn comp_op_recolor(_: u32, b: u32) -> u32 {

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -114,6 +114,11 @@ static const BlendModeInfo BLEND_MODE[] = {
 		Blendmode::Erase,
 		LayerMode
 	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Luminosity/Shine (SAI)"),
+		Blendmode::LuminosityShineSai,
+		UniversalMode
+	},
 };
 
 static const int BLEND_MODES = sizeof(BLEND_MODE)/sizeof(BlendModeInfo);

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -144,6 +144,26 @@ static const BlendModeInfo BLEND_MODE[] = {
 		Blendmode::LuminosityShineSai,
 		UniversalMode
 	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Hue"),
+		Blendmode::Hue,
+		UniversalMode
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Saturation"),
+		Blendmode::Saturation,
+		UniversalMode
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Luminosity"),
+		Blendmode::Luminosity,
+		UniversalMode
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Color"),
+		Blendmode::Color,
+		UniversalMode
+	},
 };
 
 static const int BLEND_MODES = sizeof(BLEND_MODE)/sizeof(BlendModeInfo);

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -125,6 +125,11 @@ static const BlendModeInfo BLEND_MODE[] = {
 		UniversalMode
 	},
 	{
+		QT_TRANSLATE_NOOP("blendmode", "Soft Light"),
+		Blendmode::SoftLight,
+		UniversalMode
+	},
+	{
 		QT_TRANSLATE_NOOP("blendmode", "Luminosity/Shine (SAI)"),
 		Blendmode::LuminosityShineSai,
 		UniversalMode

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -75,6 +75,11 @@ static const BlendModeInfo BLEND_MODE[] = {
 		UniversalMode
 	},
 	{
+		QT_TRANSLATE_NOOP("blendmode", "Overlay"),
+		Blendmode::Overlay,
+		UniversalMode
+	},
+	{
 		QT_TRANSLATE_NOOP("blendmode", "Divide"),
 		Blendmode::Divide,
 		UniversalMode
@@ -113,6 +118,11 @@ static const BlendModeInfo BLEND_MODE[] = {
 		QT_TRANSLATE_NOOP("blendmode", "Erase"),
 		Blendmode::Erase,
 		LayerMode
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Hard Light"),
+		Blendmode::HardLight,
+		UniversalMode
 	},
 	{
 		QT_TRANSLATE_NOOP("blendmode", "Luminosity/Shine (SAI)"),

--- a/src/libclient/canvas/blendmodes.cpp
+++ b/src/libclient/canvas/blendmodes.cpp
@@ -130,6 +130,16 @@ static const BlendModeInfo BLEND_MODE[] = {
 		UniversalMode
 	},
 	{
+		QT_TRANSLATE_NOOP("blendmode", "Linear Burn"),
+		Blendmode::LinearBurn,
+		UniversalMode
+	},
+	{
+		QT_TRANSLATE_NOOP("blendmode", "Linear Light"),
+		Blendmode::LinearLight,
+		UniversalMode
+	},
+	{
 		QT_TRANSLATE_NOOP("blendmode", "Luminosity/Shine (SAI)"),
 		Blendmode::LuminosityShineSai,
 		UniversalMode

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -70,6 +70,7 @@ enum class Blendmode : uint8_t {
   ColorErase,
   Screen,
   NormalAndEraser,
+  LuminosityShineSai,
   Replace = 255,
 };
 

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -76,6 +76,10 @@ enum class Blendmode : uint8_t {
   SoftLight,
   LinearBurn,
   LinearLight,
+  Hue,
+  Saturation,
+  Luminosity,
+  Color,
   Replace = 255,
 };
 

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -74,6 +74,8 @@ enum class Blendmode : uint8_t {
   Overlay,
   HardLight,
   SoftLight,
+  LinearBurn,
+  LinearLight,
   Replace = 255,
 };
 

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -73,6 +73,7 @@ enum class Blendmode : uint8_t {
   LuminosityShineSai,
   Overlay,
   HardLight,
+  SoftLight,
   Replace = 255,
 };
 

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -71,6 +71,8 @@ enum class Blendmode : uint8_t {
   Screen,
   NormalAndEraser,
   LuminosityShineSai,
+  Overlay,
+  HardLight,
   Replace = 255,
 };
 


### PR DESCRIPTION
This is built on top of the MyPaint stuff in #1037! so this diff currently appears to have way too much stuff in it until that's merged.

Fixes #641 because it implements Overlay and Linear Light modes.

Obsoletes #966.

Adds the following blend modes:

* Luminosity/Shine (SAI)

* Overlay and Hard Light

* Soft Light

* Linear Burn and Linear Light (Linear Dodge is just Add, which already exists)

* Hue, Saturation, Luminosity and Color

They're all available as both brush and layer modes, although they're definitely more useful for the latter.

Here's them in action (and also the Erase blend mode to vanquish the beast at the end)

https://user-images.githubusercontent.com/13625824/184942355-b399798b-880d-4143-9992-f46943d19919.mp4