### PR TITLE
15 Bit Color Channels

### DIFF
--- a/src/dpcore/benches/rasterops.rs
+++ b/src/dpcore/benches/rasterops.rs
@@ -21,14 +21,14 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use dpcore::paint::{rasterop, Blendmode, BrushMask, Pixel};
+use dpcore::paint::{rasterop, Blendmode, BrushMask, Pixel15};
 
-fn mask_blend(mask: &[u8], mode: Blendmode) {
+fn mask_blend(mask: &[u16], mode: Blendmode) {
     let mut base = [[128, 128, 128, 128]; 64 * 64];
     rasterop::mask_blend(&mut base, [255, 255, 255, 255], mask, mode, 127);
 }
 
-fn pixel_blend(over: &[Pixel], mode: Blendmode) {
+fn pixel_blend(over: &[Pixel15], mode: Blendmode) {
     let mut base = [[128, 128, 128, 128]; 64 * 64];
     rasterop::pixel_blend(&mut base, over, 128, mode);
 }

--- a/src/dpcore/examples/floodfill_samples.rs
+++ b/src/dpcore/examples/floodfill_samples.rs
@@ -47,7 +47,7 @@ fn main() {
 
     let (bgimage, w, h) = utils::load_image("testdata/filltest.png");
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         layerstack.root_mut().get_bitmaplayer_mut(1).unwrap(),
         0,
         &bgimage,
@@ -55,7 +55,7 @@ fn main() {
         1.0,
         Blendmode::Replace,
     );
-    editlayer::draw_image(
+    editlayer::draw_image8(
         layerstack.root_mut().get_bitmaplayer_mut(1).unwrap(),
         0,
         &bgimage,
@@ -311,7 +311,7 @@ fn do_floodfill(
 
     let result = expand_floodfill(result, expansion);
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         image.root_mut().get_bitmaplayer_mut(1).unwrap(),
         0,
         &result.image.pixels,

--- a/src/dpcore/examples/gimp_style_brush.rs
+++ b/src/dpcore/examples/gimp_style_brush.rs
@@ -20,7 +20,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
-use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color, Tile};
+use dpcore::paint::{
+    editlayer, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color, Tile, BIT15_U16,
+};
 
 mod utils;
 
@@ -109,6 +111,6 @@ fn draw_dab(
         &brush,
         &Color::rgb8(0, 0, 0),
         Blendmode::Normal,
-        255u8,
+        BIT15_U16,
     );
 }

--- a/src/dpcore/examples/layer_blend_dabs.rs
+++ b/src/dpcore/examples/layer_blend_dabs.rs
@@ -25,7 +25,7 @@ use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, Color, Rectang
 mod utils;
 
 fn main() {
-    let mut layer = BitmapLayer::new(0, 256, 256, Tile::Blank);
+    let mut layer = BitmapLayer::new(0, 256, 512, Tile::Blank);
 
     // Draw a nice background
     let colors = [
@@ -38,7 +38,7 @@ fn main() {
             0,
             &Color::from_argb32(c),
             Blendmode::Normal,
-            &Rectangle::new(i as i32 * 40, 0, 40, 256),
+            &Rectangle::new(i as i32 * 40, 0, 40, 512),
         );
     }
 
@@ -57,6 +57,18 @@ fn main() {
         Blendmode::Recolor,
         Blendmode::Behind,
         Blendmode::ColorErase,
+        Blendmode::Screen,
+        Blendmode::NormalAndEraser,
+        Blendmode::LuminosityShineSai,
+        Blendmode::Overlay,
+        Blendmode::HardLight,
+        Blendmode::SoftLight,
+        Blendmode::LinearBurn,
+        Blendmode::LinearLight,
+        Blendmode::Hue,
+        Blendmode::Saturation,
+        Blendmode::Luminosity,
+        Blendmode::Color,
         // Blendmode::Replace,
     ];
 

--- a/src/dpcore/examples/layer_blend_dabs.rs
+++ b/src/dpcore/examples/layer_blend_dabs.rs
@@ -71,7 +71,7 @@ fn main() {
         Blendmode::Saturation,
         Blendmode::Luminosity,
         Blendmode::Color,
-        // Blendmode::Replace,
+        Blendmode::Replace,
     ];
 
     let brush = BrushMask::new_round_pixel(10);

--- a/src/dpcore/examples/layer_blend_dabs.rs
+++ b/src/dpcore/examples/layer_blend_dabs.rs
@@ -20,7 +20,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
-use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, Color, Rectangle, Tile};
+use dpcore::paint::{
+    editlayer, BitmapLayer, Blendmode, BrushMask, Color, Rectangle, Tile, BIT15_U16,
+};
 
 mod utils;
 
@@ -86,7 +88,7 @@ fn main() {
                 &brush,
                 &dabcolor,
                 mode,
-                255u8,
+                BIT15_U16,
             );
         }
     }

--- a/src/dpcore/examples/layer_draw_dabs.rs
+++ b/src/dpcore/examples/layer_draw_dabs.rs
@@ -20,7 +20,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
-use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color, Tile};
+use dpcore::paint::{
+    editlayer, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color, Tile, BIT15_U16,
+};
 
 mod utils;
 
@@ -43,7 +45,7 @@ fn main() {
             &brush,
             &black,
             Blendmode::Normal,
-            255u8,
+            BIT15_U16,
         );
 
         let brush = BrushMask::new_round_pixel(w as u32);
@@ -55,7 +57,7 @@ fn main() {
             &brush,
             &black,
             Blendmode::Normal,
-            255u8,
+            BIT15_U16,
         );
 
         let (bx, by, brush) =
@@ -68,7 +70,7 @@ fn main() {
             &brush,
             &black,
             Blendmode::Normal,
-            255u8,
+            BIT15_U16,
         );
 
         let (bx, by, brush) =
@@ -81,7 +83,7 @@ fn main() {
             &brush,
             &black,
             Blendmode::Normal,
-            255u8,
+            BIT15_U16,
         );
 
         w += 1;

--- a/src/dpcore/examples/layer_drawimage.rs
+++ b/src/dpcore/examples/layer_drawimage.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let (image, w, h) = utils::load_image("testdata/logo.png");
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         &mut layer,
         0,
         &image,
@@ -38,7 +38,7 @@ fn main() {
         Blendmode::Replace,
     );
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         &mut layer,
         0,
         &image,
@@ -47,7 +47,7 @@ fn main() {
         Blendmode::Normal,
     );
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         &mut layer,
         0,
         &image,

--- a/src/dpcore/examples/layer_indirect.rs
+++ b/src/dpcore/examples/layer_indirect.rs
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
-use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, Color, Tile};
+use dpcore::paint::{editlayer, BitmapLayer, Blendmode, BrushMask, Color, Tile, BIT15_F32};
 
 mod utils;
 
@@ -43,7 +43,7 @@ fn brush_stroke(layer: &mut BitmapLayer, y: i32) {
             &brush,
             &black,
             Blendmode::Normal,
-            (0.4 * 255.0) as u8,
+            (0.4 * BIT15_F32) as u16,
         );
     }
 }

--- a/src/dpcore/examples/layerstack.rs
+++ b/src/dpcore/examples/layerstack.rs
@@ -22,7 +22,7 @@
 
 use dpcore::paint::tile::Tile;
 use dpcore::paint::{
-    editlayer, BitmapLayer, Blendmode, BrushMask, Color, LayerInsertion, LayerStack,
+    editlayer, BitmapLayer, Blendmode, BrushMask, Color, LayerInsertion, LayerStack, BIT15_F32,
 };
 
 mod utils;
@@ -39,7 +39,7 @@ fn brush_stroke(layer: &mut BitmapLayer, y: i32, color: &Color) {
             &brush,
             &color,
             Blendmode::Normal,
-            (0.4 * 255.0) as u8,
+            (0.4 * BIT15_F32) as u16,
         );
     }
 }

--- a/src/dpcore/examples/utils/mod.rs
+++ b/src/dpcore/examples/utils/mod.rs
@@ -32,10 +32,10 @@ fn copy_tile_to(dest: &mut Vec<u8>, stride: u32, tile: &TileData, tx: u32, ty: u
     for y in 0..TILE_SIZE {
         for x in 0..TILE_SIZE {
             let px = tile.pixels[(y * TILE_SIZE + x) as usize];
-            dest[(dest_offset + x * 4 + 0) as usize] = px[RED_CHANNEL];
-            dest[(dest_offset + x * 4 + 1) as usize] = px[GREEN_CHANNEL];
-            dest[(dest_offset + x * 4 + 2) as usize] = px[BLUE_CHANNEL];
-            dest[(dest_offset + x * 4 + 3) as usize] = px[ALPHA_CHANNEL];
+            dest[(dest_offset + x * 4 + 0) as usize] = channel15_to_8(px[RED_CHANNEL]);
+            dest[(dest_offset + x * 4 + 1) as usize] = channel15_to_8(px[GREEN_CHANNEL]);
+            dest[(dest_offset + x * 4 + 2) as usize] = channel15_to_8(px[BLUE_CHANNEL]);
+            dest[(dest_offset + x * 4 + 3) as usize] = channel15_to_8(px[ALPHA_CHANNEL]);
         }
         dest_offset += stride * 4;
     }
@@ -47,11 +47,11 @@ fn u8_mult(a: u8, b: u8) -> u8 {
 }
 
 #[allow(dead_code)]
-pub fn load_image(filename: &str) -> (Vec<Pixel>, i32, i32) {
+pub fn load_image(filename: &str) -> (Vec<Pixel8>, i32, i32) {
     let img = image::open(filename).expect("couldn't load image");
     let rgba = img.as_rgba8().unwrap();
 
-    let mut argb_data = Vec::<Pixel>::with_capacity((rgba.width() * rgba.height()) as usize);
+    let mut argb_data = Vec::<Pixel8>::with_capacity((rgba.width() * rgba.height()) as usize);
 
     for p in rgba.pixels() {
         argb_data.push([

--- a/src/dpcore/src/brush/mypaintsurface.rs
+++ b/src/dpcore/src/brush/mypaintsurface.rs
@@ -103,9 +103,7 @@ unsafe extern "C" fn get_color(
     *color_r = color.r;
     *color_g = color.g;
     *color_b = color.b;
-    // Fudge the alpha a small amount to account for rounding errors so that
-    // transparency errors don't accumulate quite as fast when blending.
-    *color_a = (color.a + (0.5 / 256.0)).min(1.0);
+    *color_a = color.a;
 }
 
 unsafe extern "C" fn begin_atomic(_parent: *mut c::MyPaintSurface) {

--- a/src/dpcore/src/canvas/brushes.rs
+++ b/src/dpcore/src/canvas/brushes.rs
@@ -21,7 +21,8 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::paint::{
-    editlayer, AoE, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color, UserID,
+    channel8_to_15, editlayer, AoE, BitmapLayer, Blendmode, BrushMask, ClassicBrushCache, Color,
+    UserID, BIT15_F32,
 };
 use crate::protocol::message::{
     DrawDabsClassicMessage, DrawDabsMyPaintMessage, DrawDabsPixelMessage,
@@ -92,7 +93,14 @@ fn drawdabs_classic_draw(
             cache,
         );
         aoe = aoe.merge(editlayer::draw_brush_dab(
-            layer, user, mx, my, &mask, &color, mode, dab.opacity,
+            layer,
+            user,
+            mx,
+            my,
+            &mask,
+            &color,
+            mode,
+            channel8_to_15(dab.opacity),
         ));
 
         last_x = x;
@@ -182,7 +190,7 @@ fn drawdabs_pixel_draw(
             &mask,
             &color,
             mode,
-            dab.opacity,
+            channel8_to_15(dab.opacity),
         ));
 
         last_x = x;
@@ -258,7 +266,7 @@ fn drawdabs_mypaint_draw(
                 &mask,
                 &color,
                 mode,
-                (normal * opacity * 255.0) as u8,
+                (normal * opacity * BIT15_F32) as u16,
             ));
         }
 
@@ -271,7 +279,7 @@ fn drawdabs_mypaint_draw(
                 &mask,
                 &color,
                 Blendmode::Recolor,
-                (lock_alpha * opacity * 255.0) as u8,
+                (lock_alpha * opacity * BIT15_F32) as u16,
             ));
         }
 

--- a/src/dpcore/src/canvas/compression.rs
+++ b/src/dpcore/src/canvas/compression.rs
@@ -21,7 +21,7 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::paint::tile::{Tile, TileData, TILE_LENGTH};
-use crate::paint::{Color, Pixel, UserID};
+use crate::paint::{Color, Pixel8, UserID};
 
 use std::convert::TryInto;
 use std::io::Write;
@@ -49,7 +49,7 @@ pub fn decompress_tile(data: &[u8], user_id: UserID) -> Option<Tile> {
         return Some(Tile::new(&Color::from_argb32(prefix), user_id));
     }
 
-    if prefix as usize != TILE_LENGTH * mem::size_of::<Pixel>() {
+    if prefix as usize != TILE_LENGTH * mem::size_of::<Pixel8>() {
         warn!(
             "decompress_tile: wrong expected output length (was {})",
             prefix
@@ -74,7 +74,7 @@ pub fn decompress_tile(data: &[u8], user_id: UserID) -> Option<Tile> {
     }
 
     let pixels =
-        unsafe { std::slice::from_raw_parts(decompressed.as_ptr() as *const Pixel, TILE_LENGTH) };
+        unsafe { std::slice::from_raw_parts(decompressed.as_ptr() as *const Pixel8, TILE_LENGTH) };
 
     Some(Tile::from_data(pixels, user_id))
 }
@@ -85,7 +85,7 @@ pub fn compress_tiledata(tiledata: &TileData) -> Vec<u8> {
     let pixelbytes = unsafe {
         slice::from_raw_parts(
             tiledata.pixels.as_ptr() as *const u8,
-            TILE_LENGTH * mem::size_of::<Pixel>(),
+            TILE_LENGTH * mem::size_of::<Pixel8>(),
         )
     };
 
@@ -114,13 +114,13 @@ pub fn compress_tile(tile: &Tile) -> Vec<u8> {
     }
 }
 
-pub fn decompress_image(data: &[u8], expected_len: usize) -> Option<Vec<Pixel>> {
+pub fn decompress_image(data: &[u8], expected_len: usize) -> Option<Vec<Pixel8>> {
     if data.len() < 4 {
         warn!("decompress_image: data too short!");
         return None;
     }
 
-    let expected_bytes_len = expected_len * mem::size_of::<Pixel>();
+    let expected_bytes_len = expected_len * mem::size_of::<Pixel8>();
     let prefix = u32::from_be_bytes(data[..4].try_into().unwrap());
     if prefix as usize != expected_bytes_len {
         warn!(
@@ -147,7 +147,7 @@ pub fn decompress_image(data: &[u8], expected_len: usize) -> Option<Vec<Pixel>> 
         return None;
     }
 
-    let pixels: Vec<Pixel> = decompressed
+    let pixels: Vec<Pixel8> = decompressed
         .chunks_exact(4)
         .map(|p| p.try_into().unwrap())
         .collect();
@@ -155,11 +155,11 @@ pub fn decompress_image(data: &[u8], expected_len: usize) -> Option<Vec<Pixel>> 
     Some(pixels)
 }
 
-pub fn compress_image(pixels: &[Pixel]) -> Vec<u8> {
+pub fn compress_image(pixels: &[Pixel8]) -> Vec<u8> {
     let pixelbytes = unsafe {
         slice::from_raw_parts(
             pixels.as_ptr() as *const u8,
-            pixels.len() * mem::size_of::<Pixel>(),
+            pixels.len() * mem::size_of::<Pixel8>(),
         )
     };
 
@@ -193,11 +193,11 @@ impl ImageCompressor {
         }
     }
 
-    pub fn add(&mut self, data: &[Pixel]) {
+    pub fn add(&mut self, data: &[Pixel8]) {
         let data = unsafe {
             slice::from_raw_parts(
                 data.as_ptr() as *const u8,
-                data.len() * mem::size_of::<Pixel>(),
+                data.len() * mem::size_of::<Pixel8>(),
             )
         };
 

--- a/src/dpcore/src/canvas/compression.rs
+++ b/src/dpcore/src/canvas/compression.rs
@@ -21,7 +21,7 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::paint::tile::{Tile, TileData, TILE_LENGTH};
-use crate::paint::{Color, Pixel8, UserID};
+use crate::paint::{pixels15_to_8, Color, Pixel8, UserID};
 
 use std::convert::TryInto;
 use std::io::Write;
@@ -82,9 +82,12 @@ pub fn decompress_tile(data: &[u8], user_id: UserID) -> Option<Tile> {
 /// Compress a tile's content.
 ///
 pub fn compress_tiledata(tiledata: &TileData) -> Vec<u8> {
+    let mut pixels8: [Pixel8; TILE_LENGTH] =
+        unsafe { mem::MaybeUninit::<[Pixel8; TILE_LENGTH]>::uninit().assume_init() };
+    pixels15_to_8(&mut pixels8, &tiledata.pixels);
     let pixelbytes = unsafe {
         slice::from_raw_parts(
-            tiledata.pixels.as_ptr() as *const u8,
+            pixels8.as_ptr() as *const u8,
             TILE_LENGTH * mem::size_of::<Pixel8>(),
         )
     };

--- a/src/dpcore/src/canvas/images.rs
+++ b/src/dpcore/src/canvas/images.rs
@@ -21,7 +21,7 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::compression::ImageCompressor;
-use crate::paint::{Blendmode, Image, LayerID, Rectangle, UserID};
+use crate::paint::{Blendmode, Image8, LayerID, Rectangle, UserID};
 use crate::protocol::message::{CommandMessage, PutImageMessage};
 
 const MAX_IMAGE_LEN: usize = 0xffff - 19;
@@ -35,7 +35,7 @@ pub fn make_putimage(
     layer: LayerID,
     x: u32,
     y: u32,
-    image: &Image,
+    image: &Image8,
     mode: Blendmode,
 ) -> Vec<CommandMessage> {
     let mut messages = Vec::new();
@@ -59,7 +59,7 @@ fn make_putimage_crop(
     layer: LayerID,
     x: u32,
     y: u32,
-    image: &Image,
+    image: &Image8,
     mode: Blendmode,
     rect: &Rectangle,
 ) {

--- a/src/dpcore/src/canvas/state.rs
+++ b/src/dpcore/src/canvas/state.rs
@@ -350,7 +350,7 @@ impl CanvasState {
                         } else if let Some(imagedata) =
                             compression::decompress_image(&m.image, (m.w * m.h) as usize)
                         {
-                            editlayer::draw_image(
+                            editlayer::draw_image8(
                                 layer,
                                 0,
                                 &imagedata,
@@ -872,7 +872,7 @@ impl CanvasState {
                 compression::decompress_image(&msg.image, (msg.w * msg.h) as usize)
             {
                 let mode = Blendmode::try_from(msg.mode).unwrap_or_default();
-                let aoe = editlayer::draw_image(
+                let aoe = editlayer::draw_image8(
                     layer,
                     user_id,
                     &imagedata,

--- a/src/dpcore/src/paint/grouplayer.rs
+++ b/src/dpcore/src/paint/grouplayer.rs
@@ -23,7 +23,7 @@
 use super::aoe::{AoE, TileMap};
 use super::bitmaplayer::BitmapLayer;
 use super::blendmode::Blendmode;
-use super::color::{Color, ALPHA_CHANNEL, ZERO_PIXEL};
+use super::color::{Color, ALPHA_CHANNEL, ZERO_PIXEL15};
 use super::idgenerator::IDGenerator;
 use super::layer::{Layer, LayerMetadata};
 use super::rect::Size;
@@ -517,7 +517,7 @@ impl GroupLayer {
         };
 
         if self.metadata.isolated {
-            let mut tmp = TileData::new(ZERO_PIXEL, 0);
+            let mut tmp = TileData::new(ZERO_PIXEL15, 0);
             flatten(&mut tmp);
             destination.merge_data(&tmp, 1.0, self.metadata.blendmode);
         } else {

--- a/src/dpcore/src/paint/mod.rs
+++ b/src/dpcore/src/paint/mod.rs
@@ -58,8 +58,8 @@ pub use bitmaplayer::BitmapLayer;
 pub use blendmode::Blendmode;
 pub use brushmask::{BrushMask, ClassicBrushCache};
 pub use color::{
-    channel15_to_8, channel8_to_15, pixel15_to_8, pixel8_to_15, Color, Pixel15, Pixel8, BIT15_F32,
-    BIT15_U16,
+    channel15_to_8, channel8_to_15, pixel15_to_8, pixel8_to_15, pixels15_to_8, pixels8_to_15,
+    Color, Pixel15, Pixel8, BIT15_F32, BIT15_U16,
 };
 pub use flattenediter::FlattenedTileIterator;
 pub use grouplayer::{GroupLayer, LayerInsertion, RootGroup};

--- a/src/dpcore/src/paint/mod.rs
+++ b/src/dpcore/src/paint/mod.rs
@@ -52,12 +52,15 @@ mod layer;
 mod rect;
 mod timeline;
 
-pub use self::image::Image;
+pub use self::image::{Image15, Image8};
 pub use aoe::AoE;
 pub use bitmaplayer::BitmapLayer;
 pub use blendmode::Blendmode;
 pub use brushmask::{BrushMask, ClassicBrushCache};
-pub use color::{Color, Pixel};
+pub use color::{
+    channel15_to_8, channel8_to_15, pixel15_to_8, pixel8_to_15, Color, Pixel15, Pixel8, BIT15_F32,
+    BIT15_U16,
+};
 pub use flattenediter::FlattenedTileIterator;
 pub use grouplayer::{GroupLayer, LayerInsertion, RootGroup};
 pub use layer::{Layer, LayerMetadata};

--- a/src/dpcore/tests/test_timeline.rs
+++ b/src/dpcore/tests/test_timeline.rs
@@ -21,11 +21,11 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use dpcore::canvas::CanvasState;
-use dpcore::paint::color::ZERO_PIXEL;
+use dpcore::paint::color::ZERO_PIXEL8;
 use dpcore::paint::*;
 use dpcore::protocol::message::{CommandMessage, Message};
 
-const BLACK_PIXEL: Pixel = [0, 0, 0, 255];
+const BLACK_PIXEL8: Pixel8 = [0, 0, 0, 255];
 
 #[test]
 fn test_timeline() {
@@ -63,25 +63,25 @@ fn test_timeline() {
 
     // The canvas starts out in auto-timeline mode where each
     // frame corresponds to a top-level layer
-    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 0), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 0), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 1), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 1), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 2), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 2), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 2), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 2), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 3), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 3), BLACK_PIXEL8);
 
     // Now, let's active the custom timeline
     // The frames will be:
@@ -107,59 +107,59 @@ fn test_timeline() {
         "1 settimelineframe frame=4 layers=0x0101,0,0,0,0,0,0,0,0,0,0,0",
     ));
 
-    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 0), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 0), BLACK_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 1), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 1), BLACK_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 2), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 2), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 2), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 2), BLACK_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 3), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 3), BLACK_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 4), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 4), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 4), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 4), ZERO_PIXEL8);
 
     // Frames outside the assigned range are blank
-    assert_eq!(color_at(&canvas, t1, 5), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 5), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 5), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 5), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 5), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 5), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 5), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 5), ZERO_PIXEL8);
 
     // Let's try deleting the first frame
     canvas.receive_message(&m("1 removetimelineframe frame=0"));
 
-    assert_eq!(color_at(&canvas, t1, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 0), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 0), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 0), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 0), BLACK_PIXEL8);
 
     // Then insert a new one in its place
     canvas.receive_message(&m(
         "1 settimelineframe frame=0 insert=true layers=0x0101,0,0,0,0,0,0,0,0,0,0,0",
     ));
 
-    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 0), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 0), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 0), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, t4, 1), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, t1, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t2, 1), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, t3, 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, t4, 1), BLACK_PIXEL8);
 }
 
 #[test]
@@ -228,35 +228,35 @@ fn test_timeline_groups() {
 
     // Enable custom timeline
     canvas.receive_message(&m("1 setmetadataint field=3 value=1"));
-    assert_eq!(color_at(&canvas, (1, 1), 0), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 2), 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (2, 2), 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 3), 0), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 4), 0), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, (1, 1), 0), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 2), 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (2, 2), 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 3), 0), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 4), 0), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, (1, 1), 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 2), 1), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, (2, 2), 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 3), 1), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 4), 1), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, (1, 1), 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 2), 1), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, (2, 2), 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 3), 1), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 4), 1), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, (1, 1), 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 2), 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (2, 2), 2), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 3), 2), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 4), 2), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, (1, 1), 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 2), 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (2, 2), 2), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 3), 2), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 4), 2), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, (1, 1), 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 2), 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (2, 2), 3), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 3), 3), BLACK_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 4), 3), ZERO_PIXEL);
+    assert_eq!(color_at(&canvas, (1, 1), 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 2), 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (2, 2), 3), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 3), 3), BLACK_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 4), 3), ZERO_PIXEL8);
 
-    assert_eq!(color_at(&canvas, (1, 1), 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 2), 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (2, 2), 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 3), 4), ZERO_PIXEL);
-    assert_eq!(color_at(&canvas, (1, 4), 4), BLACK_PIXEL);
+    assert_eq!(color_at(&canvas, (1, 1), 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 2), 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (2, 2), 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 3), 4), ZERO_PIXEL8);
+    assert_eq!(color_at(&canvas, (1, 4), 4), BLACK_PIXEL8);
 }
 
 fn m(msg: &str) -> CommandMessage {
@@ -266,7 +266,7 @@ fn m(msg: &str) -> CommandMessage {
     }
 }
 
-fn color_at(canvas: &CanvasState, pos: (usize, usize), frame: isize) -> Pixel {
+fn color_at(canvas: &CanvasState, pos: (usize, usize), frame: isize) -> Pixel8 {
     let img = canvas.layerstack().to_image(&LayerViewOptions::frame(
         canvas.layerstack().frame_at(frame),
     ));

--- a/src/dpimpex/src/animation.rs
+++ b/src/dpimpex/src/animation.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use super::conv::from_dpimage;
 use crate::{ImageExportResult, ImpexError};
-use dpcore::paint::{Image, LayerStack, LayerViewOptions};
+use dpcore::paint::{Image8, LayerStack, LayerViewOptions};
 
 use image::codecs::gif::{GifEncoder, Repeat};
 use image::{Delay, Frame};
@@ -15,7 +15,7 @@ pub trait AnimationWriter {
 }
 
 pub trait FrameWriter {
-    fn write_frame(&mut self, frame: &Image, duration: Duration) -> ImageExportResult;
+    fn write_frame(&mut self, frame: &Image8, duration: Duration) -> ImageExportResult;
 }
 
 pub struct AnimationSaver<W: FrameWriter> {
@@ -75,7 +75,7 @@ impl GifWriter {
 }
 
 impl FrameWriter for GifWriter {
-    fn write_frame(&mut self, frame: &Image, duration: Duration) -> ImageExportResult {
+    fn write_frame(&mut self, frame: &Image8, duration: Duration) -> ImageExportResult {
         // TODO subframe delta
         self.encoder.encode_frame(Frame::from_parts(
             from_dpimage(frame),
@@ -104,7 +104,7 @@ impl FrameImagesWriter {
 }
 
 impl FrameWriter for FrameImagesWriter {
-    fn write_frame(&mut self, frame: &Image, _duration: Duration) -> ImageExportResult {
+    fn write_frame(&mut self, frame: &Image8, _duration: Duration) -> ImageExportResult {
         let mut pb = self.dir.clone();
         pb.push(format!("frame-{:03}.png", self.next_number));
 

--- a/src/dpimpex/src/conv.rs
+++ b/src/dpimpex/src/conv.rs
@@ -21,15 +21,15 @@
 // along with Drawpile.  If not, see <https://www.gnu.org/licenses/>.
 
 use dpcore::paint::color::*;
-use dpcore::paint::Image;
+use dpcore::paint::Image8;
 use image::RgbaImage;
 
-pub fn to_dpimage(img: &RgbaImage) -> Image {
-    let mut dpimg = Image::new(img.width() as usize, img.height() as usize);
+pub fn to_dpimage(img: &RgbaImage) -> Image8 {
+    let mut dpimg = Image8::new(img.width() as usize, img.height() as usize);
 
     let pixels = unsafe {
         std::slice::from_raw_parts(
-            img.as_raw().as_ptr() as *const Pixel,
+            img.as_raw().as_ptr() as *const Pixel8,
             dpimg.width * dpimg.height,
         )
     };
@@ -50,7 +50,7 @@ pub fn to_dpimage(img: &RgbaImage) -> Image {
     dpimg
 }
 
-pub fn from_dpimage(img: &Image) -> RgbaImage {
+pub fn from_dpimage(img: &Image8) -> RgbaImage {
     let mut rgba = Vec::with_capacity(img.width * img.height * 4);
 
     // Unpremultiply pixel values

--- a/src/dpimpex/src/flat.rs
+++ b/src/dpimpex/src/flat.rs
@@ -46,7 +46,7 @@ pub fn load_flat_image(path: &Path) -> ImageImportResult {
         .unwrap();
     layer.metadata_mut().title = "Layer 1".into();
 
-    editlayer::draw_image(
+    editlayer::draw_image8(
         layer.as_bitmap_mut().unwrap(),
         1,
         &img.pixels,
@@ -79,7 +79,7 @@ pub fn load_gif_animation(path: &Path) -> ImageImportResult {
         let frame = frame?;
         let img = to_dpimage(frame.buffer());
 
-        editlayer::draw_image(
+        editlayer::draw_image8(
             layer,
             1,
             &img.pixels,
@@ -150,7 +150,7 @@ mod tests {
                 r: 1.0,
                 g: 1.0,
                 b: 1.0,
-                a: 0.502
+                a: 0.5019531
             }
         );
     }

--- a/src/dpimpex/src/ora/reader.rs
+++ b/src/dpimpex/src/ora/reader.rs
@@ -29,7 +29,7 @@ use crate::{ImageImportResult, ImpexError};
 
 use dpcore::paint::annotation::VAlign;
 use dpcore::paint::{
-    editlayer, Blendmode, Color, Frame, Image, LayerID, LayerInsertion, LayerStack, Rectangle,
+    editlayer, Blendmode, Color, Frame, Image8, LayerID, LayerInsertion, LayerStack, Rectangle,
     Size, Tile,
 };
 
@@ -153,7 +153,7 @@ fn create_stack<R: Read + Seek>(
 
                 // TODO layer lock status
 
-                editlayer::draw_image(
+                editlayer::draw_image8(
                     layer,
                     1,
                     &img.pixels,
@@ -195,7 +195,7 @@ fn check_mimetype<R: Read + Seek>(archive: &mut ZipArchive<R>) -> Result<(), Imp
 fn get_image_file<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
     filename: &str,
-) -> Result<Image, ImpexError> {
+) -> Result<Image8, ImpexError> {
     let mut filecontent = Vec::new();
     archive.by_name(filename)?.read_to_end(&mut filecontent)?;
     let img = ImageReader::new(Cursor::new(filecontent))

--- a/src/dpimpex/src/ora/writer.rs
+++ b/src/dpimpex/src/ora/writer.rs
@@ -28,7 +28,7 @@ use crate::{ImageExportResult, ImpexError};
 use dpcore::paint::annotation::VAlign;
 use dpcore::paint::tile::TILE_SIZEI;
 use dpcore::paint::{
-    BitmapLayer, Blendmode, GroupLayer, Image, Layer, LayerID, LayerStack, LayerViewOptions,
+    BitmapLayer, Blendmode, GroupLayer, Image8, Layer, LayerID, LayerStack, LayerViewOptions,
     Rectangle,
 };
 
@@ -94,7 +94,7 @@ fn write_background<W: Write + Seek>(
         archive,
         &filename,
         &from_dpimage(
-            &bgl.to_image(Rectangle::new(
+            &bgl.to_image8(Rectangle::new(
                 0,
                 0,
                 bgl.width() as i32,
@@ -104,8 +104,8 @@ fn write_background<W: Write + Seek>(
         ),
     )?;
 
-    let mut bgt = Image::new(TILE_SIZEI as usize, TILE_SIZEI as usize);
-    bgl.to_pixels(Rectangle::tile(0, 0, TILE_SIZEI), &mut bgt.pixels)
+    let mut bgt = Image8::new(TILE_SIZEI as usize, TILE_SIZEI as usize);
+    bgl.to_pixels8(Rectangle::tile(0, 0, TILE_SIZEI), &mut bgt.pixels)
         .unwrap();
     write_png(archive, &tilename, &from_dpimage(&bgt))?;
 
@@ -130,7 +130,7 @@ fn write_layer<W: Write + Seek>(
     archive: &mut ZipWriter<W>,
     layer: &BitmapLayer,
 ) -> Result<OraLayer, ImpexError> {
-    let (image, x, y) = layer.to_cropped_image();
+    let (image, x, y) = layer.to_cropped_image8();
     let md = layer.metadata();
 
     let ol = OraLayer {
@@ -153,7 +153,7 @@ fn write_layer<W: Write + Seek>(
         write_png(archive, &ol.filename, &from_dpimage(&image))?;
     } else {
         let blank = layer
-            .to_image(Rectangle::new(
+            .to_image8(Rectangle::new(
                 0,
                 0,
                 layer.width() as i32,

--- a/src/rustpile/src/brushes_ffi.rs
+++ b/src/rustpile/src/brushes_ffi.rs
@@ -3,7 +3,7 @@ use dpcore::brush::{
     BrushEngine, BrushState, ClassicBrush, ClassicBrushShape, MyPaintBrush, MyPaintSettings,
 };
 use dpcore::paint::rectiter::{MutableRectIterator, RectIterator};
-use dpcore::paint::{BrushMask, ClassicBrushCache, Color, LayerID, Pixel, Rectangle, Size};
+use dpcore::paint::{BrushMask, ClassicBrushCache, Color, LayerID, Pixel8, Rectangle, Size};
 use dpcore::protocol::MessageWriter;
 
 use std::slice;
@@ -94,7 +94,7 @@ pub extern "C" fn brush_preview_dab(
     color: &Color,
 ) {
     let pixel_slice =
-        unsafe { slice::from_raw_parts_mut(image as *mut Pixel, (width * height) as usize) };
+        unsafe { slice::from_raw_parts_mut(image as *mut Pixel8, (width * height) as usize) };
 
     let mask = match brush.shape {
         ClassicBrushShape::RoundPixel => BrushMask::new_round_pixel(brush.size.1 as u32),
@@ -132,7 +132,7 @@ pub extern "C" fn brush_preview_dab(
                     b: color.b,
                     a: val as f32 / 255.0 * brush.opacity.1,
                 }
-                .as_pixel()
+                .as_pixel8()
             });
         });
 }

--- a/src/rustpile/src/brushpreview.rs
+++ b/src/rustpile/src/brushpreview.rs
@@ -22,10 +22,9 @@
 
 use dpcore::brush::{BrushEngine, BrushState, ClassicBrush, MyPaintBrush, MyPaintSettings};
 use dpcore::canvas::brushes;
-use dpcore::paint::tile::Tile;
 use dpcore::paint::{
     editlayer, floodfill, Blendmode, BrushMask, ClassicBrushCache, Color, LayerID, LayerInsertion,
-    LayerStack, Rectangle,
+    LayerStack, Rectangle, Tile, BIT15_U16,
 };
 use dpcore::protocol::message::CommandMessage;
 
@@ -179,7 +178,7 @@ impl BrushPreview {
                         &dabmask,
                         &color,
                         Blendmode::Normal,
-                        255u8,
+                        BIT15_U16,
                     );
                     hue += huestep;
                 }
@@ -318,7 +317,7 @@ impl BrushPreview {
             result = floodfill::expand_floodfill(result, expansion);
         }
 
-        editlayer::draw_image(
+        editlayer::draw_image8(
             self.layerstack
                 .root_mut()
                 .get_bitmaplayer_mut(LAYER_ID)

--- a/src/rustpile/src/brushpreview_ffi.rs
+++ b/src/rustpile/src/brushpreview_ffi.rs
@@ -22,7 +22,8 @@
 
 use super::brushpreview::{BrushPreview, BrushPreviewShape};
 use dpcore::brush::{ClassicBrush, MyPaintBrush, MyPaintSettings};
-use dpcore::paint::tile::TILE_SIZEI;
+use dpcore::paint::color::{pixels15_to_8, ZERO_PIXEL8};
+use dpcore::paint::tile::{TILE_LENGTH, TILE_SIZEI};
 use dpcore::paint::{AoE, Color, FlattenedTileIterator, LayerViewOptions};
 
 use core::ffi::c_void;
@@ -76,12 +77,14 @@ pub extern "C" fn brushpreview_paint(
     paint_func: extern "C" fn(ctx: *mut c_void, x: i32, y: i32, pixels: *const u8),
 ) {
     let opts = LayerViewOptions::default();
+    let mut pixels = [ZERO_PIXEL8; TILE_LENGTH];
     FlattenedTileIterator::new(&bp.layerstack, &opts, AoE::Everything).for_each(|(i, j, t)| {
+        pixels15_to_8(&mut pixels, &t.pixels);
         paint_func(
             ctx,
             i * TILE_SIZEI,
             j * TILE_SIZEI,
-            t.pixels.as_ptr() as *const u8,
+            pixels.as_ptr() as *const u8,
         )
     });
 }

--- a/src/rustpile/src/messages_ffi.rs
+++ b/src/rustpile/src/messages_ffi.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::redundant_field_names)]
 
 use dpcore::canvas::images::make_putimage;
-use dpcore::paint::{Blendmode, Image, LayerID, Pixel, UserID};
+use dpcore::paint::{Blendmode, Image8, LayerID, Pixel8, UserID};
 use dpcore::protocol::message::*;
 use dpcore::protocol::MessageWriter;
 use std::slice;
@@ -557,10 +557,10 @@ pub extern "C" fn write_putimage(
     pixels: *const u8,
 ) {
     // TODO ImageRef type so we don't need to make copies
-    let mut image = Image::new(w as usize, h as usize);
+    let mut image = Image8::new(w as usize, h as usize);
 
     image.pixels[..].copy_from_slice(unsafe {
-        slice::from_raw_parts_mut(pixels as *mut Pixel, (w * h) as usize)
+        slice::from_raw_parts_mut(pixels as *mut Pixel8, (w * h) as usize)
     });
 
     make_putimage(user, layer, x, y, &image, mode)

--- a/src/rustpile/src/snapshots.rs
+++ b/src/rustpile/src/snapshots.rs
@@ -1,4 +1,4 @@
-use dpcore::paint::{LayerStack, LayerViewOptions, Pixel, Rectangle, Size};
+use dpcore::paint::{LayerStack, LayerViewOptions, Pixel8, Rectangle, Size};
 
 use std::collections::VecDeque;
 use std::slice;
@@ -80,11 +80,11 @@ pub extern "C" fn snapshots_get_content(
     if let Some(s) = snapshots.snapshots.get(index) {
         let size = s.layerstack.root().size();
         let pixel_slice = unsafe {
-            slice::from_raw_parts_mut(pixels as *mut Pixel, (size.width * size.height) as usize)
+            slice::from_raw_parts_mut(pixels as *mut Pixel8, (size.width * size.height) as usize)
         };
 
         s.layerstack
-            .to_pixels(
+            .to_pixels8(
                 Rectangle::new(0, 0, size.width, size.height),
                 &LayerViewOptions::default(),
                 pixel_slice,


### PR DESCRIPTION
Like MyPaint does it. Makes blending and stuff far more accurate, with less artifacting and weird transparency issues when smudging. This doesn't change anything about the wire protocol, that still uses 8 bits everywhere and seems to work great that way, I don't think the added precision would really do much there.

Pixel and Image now come as Pixel8/Pixel15 and Image8/Image15 dichotomies. Translation doesn't seem to be much an issue, since most applications operate on stuff a tile at a time or a line at a time, so we don't need to buffer huge stretches of pixels.

Also removes the color sample fudging from MyPaintSurface and, since I used it for comparisons along the way, adds the new blend modes to the layer_blend_dabs example.