### PR TITLE
MyPaint Brush Improvements

### DIFF
--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -416,12 +416,12 @@ void CanvasView::leaveEvent(QEvent *event)
 	updateOutline();
 }
 
-canvas::Point CanvasView::mapToScene(const QPoint &point, qreal pressure) const
+canvas::Point CanvasView::mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt) const
 {
-	return canvas::Point(mapToScene(point), pressure);
+	return canvas::Point(mapToScene(point), pressure, xtilt, ytilt);
 }
 
-canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure) const
+canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt) const
 {
 	// QGraphicsView API lacks mapToScene(QPointF), even though
 	// the QPoint is converted to QPointF internally...
@@ -440,7 +440,7 @@ canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure) const
 		(p1.y()-p2.y()) * yf + p2.y()
 	);
 
-	return canvas::Point(mapped, pressure);
+	return canvas::Point(mapped, pressure, xtilt, ytilt);
 }
 
 void CanvasView::setPointerTracking(bool tracking)
@@ -505,7 +505,7 @@ void CanvasView::onPenUp()
 	updateOutline();
 }
 
-void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus)
+void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus)
 {
 	if(m_pendown != NOTDOWN)
 		return;
@@ -521,14 +521,14 @@ void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, Qt::MouseButt
 		m_pendown = isStylus ? TABLETDOWN : MOUSEDOWN;
 		m_pointerdistance = 0;
 		m_pointervelocity = 0;
-		m_prevpoint = mapToScene(pos, pressure);
+		m_prevpoint = mapToScene(pos, pressure, xtilt, ytilt);
 
 		m_penmode = PenMode(CanvasViewShortcuts::matches(
 			modifiers,
 			m_shortcuts.colorPick, m_shortcuts.layerPick
 		) + 1);
 
-		onPenDown(mapToScene(pos, mapPressure(pressure, isStylus)), button == Qt::RightButton);
+		onPenDown(mapToScene(pos, mapPressure(pressure, isStylus), xtilt, ytilt), button == Qt::RightButton);
 	}
 }
 
@@ -540,20 +540,22 @@ void CanvasView::mousePressEvent(QMouseEvent *event)
 
 	penPressEvent(
 		event->pos(),
-		1,
+		1.0,
+		0.0,
+		0.0,
 		event->button(),
 		event->modifiers(),
 		false
 	);
 }
 
-void CanvasView::penMoveEvent(const QPointF &pos, qreal pressure, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus)
+void CanvasView::penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus)
 {
 	if(m_dragmode == ViewDragMode::Started) {
 		moveDrag(pos.toPoint(), modifiers);
 
 	} else {
-		canvas::Point point = mapToScene(pos, pressure);
+		canvas::Point point = mapToScene(pos, pressure, xtilt, ytilt);
 		updateOutline(point);
 		if(!m_prevpoint.intSame(point)) {
 			if(m_pendown) {
@@ -595,6 +597,8 @@ void CanvasView::mouseMoveEvent(QMouseEvent *event)
 	penMoveEvent(
 		event->pos(),
 		1.0,
+		0.0,
+		0.0,
 		event->buttons(),
 		event->modifiers(),
 		false
@@ -603,7 +607,7 @@ void CanvasView::mouseMoveEvent(QMouseEvent *event)
 
 void CanvasView::penReleaseEvent(const QPointF &pos, Qt::MouseButton button)
 {
-	m_prevpoint = mapToScene(pos, 0.0);
+	m_prevpoint = mapToScene(pos, 0.0, 0.0, 0.0);
 	if(m_dragmode != ViewDragMode::None) {
 		if(m_spacebar)
 			m_dragmode = ViewDragMode::Prepared;
@@ -855,6 +859,8 @@ bool CanvasView::viewportEvent(QEvent *event)
 		penPressEvent(
 			tabev->posF(),
 			tabev->pressure(),
+			tabev->xTilt(),
+			tabev->yTilt(),
 			tabev->button(),
 			QApplication::queryKeyboardModifiers(), // TODO check if tablet event modifiers() is still broken in Qt 5.12
 			true
@@ -868,6 +874,8 @@ bool CanvasView::viewportEvent(QEvent *event)
 		penMoveEvent(
 			tabev->posF(),
 			tabev->pressure(),
+			tabev->xTilt(),
+			tabev->yTilt(),
 			tabev->buttons(),
 			QApplication::queryKeyboardModifiers(), // TODO check if tablet event modifiers() is still broken in Qt 5.12
 			true

--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -416,12 +416,12 @@ void CanvasView::leaveEvent(QEvent *event)
 	updateOutline();
 }
 
-canvas::Point CanvasView::mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt) const
+canvas::Point CanvasView::mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation) const
 {
-	return canvas::Point(mapToScene(point), pressure, xtilt, ytilt);
+	return canvas::Point(mapToScene(point), pressure, xtilt, ytilt, rotation);
 }
 
-canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt) const
+canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation) const
 {
 	// QGraphicsView API lacks mapToScene(QPointF), even though
 	// the QPoint is converted to QPointF internally...
@@ -440,7 +440,7 @@ canvas::Point CanvasView::mapToScene(const QPointF &point, qreal pressure, qreal
 		(p1.y()-p2.y()) * yf + p2.y()
 	);
 
-	return canvas::Point(mapped, pressure, xtilt, ytilt);
+	return canvas::Point(mapped, pressure, xtilt, ytilt, rotation);
 }
 
 void CanvasView::setPointerTracking(bool tracking)
@@ -505,7 +505,7 @@ void CanvasView::onPenUp()
 	updateOutline();
 }
 
-void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus)
+void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus)
 {
 	if(m_pendown != NOTDOWN)
 		return;
@@ -521,14 +521,14 @@ void CanvasView::penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, 
 		m_pendown = isStylus ? TABLETDOWN : MOUSEDOWN;
 		m_pointerdistance = 0;
 		m_pointervelocity = 0;
-		m_prevpoint = mapToScene(pos, pressure, xtilt, ytilt);
+		m_prevpoint = mapToScene(pos, pressure, xtilt, ytilt, rotation);
 
 		m_penmode = PenMode(CanvasViewShortcuts::matches(
 			modifiers,
 			m_shortcuts.colorPick, m_shortcuts.layerPick
 		) + 1);
 
-		onPenDown(mapToScene(pos, mapPressure(pressure, isStylus), xtilt, ytilt), button == Qt::RightButton);
+		onPenDown(mapToScene(pos, mapPressure(pressure, isStylus), xtilt, ytilt, rotation), button == Qt::RightButton);
 	}
 }
 
@@ -543,19 +543,20 @@ void CanvasView::mousePressEvent(QMouseEvent *event)
 		1.0,
 		0.0,
 		0.0,
+		0.0,
 		event->button(),
 		event->modifiers(),
 		false
 	);
 }
 
-void CanvasView::penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus)
+void CanvasView::penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus)
 {
 	if(m_dragmode == ViewDragMode::Started) {
 		moveDrag(pos.toPoint(), modifiers);
 
 	} else {
-		canvas::Point point = mapToScene(pos, pressure, xtilt, ytilt);
+		canvas::Point point = mapToScene(pos, pressure, xtilt, ytilt, rotation);
 		updateOutline(point);
 		if(!m_prevpoint.intSame(point)) {
 			if(m_pendown) {
@@ -599,6 +600,7 @@ void CanvasView::mouseMoveEvent(QMouseEvent *event)
 		1.0,
 		0.0,
 		0.0,
+		0.0,
 		event->buttons(),
 		event->modifiers(),
 		false
@@ -607,7 +609,7 @@ void CanvasView::mouseMoveEvent(QMouseEvent *event)
 
 void CanvasView::penReleaseEvent(const QPointF &pos, Qt::MouseButton button)
 {
-	m_prevpoint = mapToScene(pos, 0.0, 0.0, 0.0);
+	m_prevpoint = mapToScene(pos, 0.0, 0.0, 0.0, 0.0);
 	if(m_dragmode != ViewDragMode::None) {
 		if(m_spacebar)
 			m_dragmode = ViewDragMode::Prepared;
@@ -861,6 +863,7 @@ bool CanvasView::viewportEvent(QEvent *event)
 			tabev->pressure(),
 			tabev->xTilt(),
 			tabev->yTilt(),
+			tabev->rotation(),
 			tabev->button(),
 			QApplication::queryKeyboardModifiers(), // TODO check if tablet event modifiers() is still broken in Qt 5.12
 			true
@@ -876,6 +879,7 @@ bool CanvasView::viewportEvent(QEvent *event)
 			tabev->pressure(),
 			tabev->xTilt(),
 			tabev->yTilt(),
+			tabev->rotation(),
 			tabev->buttons(),
 			QApplication::queryKeyboardModifiers(), // TODO check if tablet event modifiers() is still broken in Qt 5.12
 			true

--- a/src/desktop/scene/canvasview.h
+++ b/src/desktop/scene/canvasview.h
@@ -60,8 +60,8 @@ public:
 	qreal rotation() const { return m_rotate; }
 
 	using QGraphicsView::mapToScene;
-	canvas::Point mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt) const;
-	canvas::Point mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt) const;
+	canvas::Point mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation) const;
+	canvas::Point mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation) const;
 
 	//! The center point of the view in scene coordinates
 	QPoint viewCenterPoint() const;
@@ -196,8 +196,8 @@ protected:
 
 private:
 	// unified mouse/stylus event handlers
-	void penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus);
-	void penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus);
+	void penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus);
+	void penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, qreal rotation, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus);
 	void penReleaseEvent(const QPointF &pos, Qt::MouseButton button);
 
 private:

--- a/src/desktop/scene/canvasview.h
+++ b/src/desktop/scene/canvasview.h
@@ -60,8 +60,8 @@ public:
 	qreal rotation() const { return m_rotate; }
 
 	using QGraphicsView::mapToScene;
-	canvas::Point mapToScene(const QPoint &point, qreal pressure) const;
-	canvas::Point mapToScene(const QPointF &point, qreal pressure) const;
+	canvas::Point mapToScene(const QPoint &point, qreal pressure, qreal xtilt, qreal ytilt) const;
+	canvas::Point mapToScene(const QPointF &point, qreal pressure, qreal xtilt, qreal ytilt) const;
 
 	//! The center point of the view in scene coordinates
 	QPoint viewCenterPoint() const;
@@ -196,8 +196,8 @@ protected:
 
 private:
 	// unified mouse/stylus event handlers
-	void penPressEvent(const QPointF &pos, qreal pressure, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus);
-	void penMoveEvent(const QPointF &pos, qreal pressure, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus);
+	void penPressEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButton button, Qt::KeyboardModifiers modifiers, bool isStylus);
+	void penMoveEvent(const QPointF &pos, qreal pressure, qreal xtilt, qreal ytilt, Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, bool isStylus);
 	void penReleaseEvent(const QPointF &pos, Qt::MouseButton button);
 
 private:

--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -243,7 +243,6 @@ QWidget *BrushSettings::createUiWidget(QWidget *parent)
 	connect(d->ui.colorpickup, &QSlider::valueChanged, this, &BrushSettings::updateFromUi);
 	connect(d->ui.brushspacingBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &BrushSettings::updateFromUi);
 	connect(d->ui.gainBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &BrushSettings::updateFromUi);
-	connect(d->ui.paintModeBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &BrushSettings::updateFromUi);
 	connect(d->ui.slowTrackingBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &BrushSettings::updateFromUi);
 
 	connect(d->ui.modeIncremental, &QToolButton::clicked, this, &BrushSettings::updateFromUi);
@@ -476,8 +475,6 @@ void BrushSettings::updateUi()
 		(myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC].base_value + 2.0) * 100.0);
 	d->ui.gainBox->setValue(qRound(
 		myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_PRESSURE_GAIN_LOG].base_value * 100.0));
-	d->ui.paintModeBox->setValue(qRound(
-		myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_PAINT_MODE].base_value * 100.0));
 	d->ui.slowTrackingBox->setValue(qRound(
 		myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_SLOW_TRACKING].base_value * 10.0));
 	d->ui.modeLockAlpha->setChecked(myPaint.constBrush().lock_alpha);
@@ -551,8 +548,6 @@ void BrushSettings::updateFromUi()
 		d->ui.brushhardness->value() / 100.0;
 	myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_PRESSURE_GAIN_LOG].base_value =
 		d->ui.gainBox->value() / 100.0;
-	myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_PAINT_MODE].base_value =
-		d->ui.paintModeBox->value() / 100.0;
 	myPaintSettings.mappings[MYPAINT_BRUSH_SETTING_SLOW_TRACKING].base_value =
 		d->ui.slowTrackingBox->value() / 10.0;
 	myPaint.brush().lock_alpha = d->ui.modeLockAlpha->isChecked();
@@ -599,9 +594,6 @@ void BrushSettings::adjustSettingVisibilities(bool softmode, bool mypaintmode)
 		{d->ui.gainLabel, mypaintmode},
 		{d->ui.gainSlider, mypaintmode},
 		{d->ui.gainBox, mypaintmode},
-		{d->ui.paintModeLabel, mypaintmode},
-		{d->ui.paintModeSlider, mypaintmode},
-		{d->ui.paintModeBox, mypaintmode},
 		{d->ui.slowTrackingLabel, mypaintmode},
 		{d->ui.slowTrackingSlider, mypaintmode},
 		{d->ui.slowTrackingBox, mypaintmode},

--- a/src/desktop/toolwidgets/brushsettings.cpp
+++ b/src/desktop/toolwidgets/brushsettings.cpp
@@ -391,7 +391,7 @@ void BrushSettings::changeSizeSetting(int size)
 void BrushSettings::changeRadiusLogarithmicSetting(int radiusLogarithmic)
 {
 	if(d->ui.radiusLogarithmicBox->isVisible()) {
-		emit pixelSizeChanged(std::exp(radiusLogarithmic / 100.0 - 2.0));
+		emit pixelSizeChanged(radiusLogarithmicToPixelSize(radiusLogarithmic));
 	}
 }
 
@@ -790,7 +790,11 @@ void BrushSettings::quickAdjustOn(QSpinBox *box, qreal adjustment)
 
 int BrushSettings::getSize() const
 {
-	return d->ui.brushsizeBox->value();
+	if(d->ui.brushsizeBox->isVisible()) {
+		return d->ui.brushsizeBox->value();
+	} else {
+		return radiusLogarithmicToPixelSize(d->ui.radiusLogarithmicBox->value());
+	}
 }
 
 bool BrushSettings::getSubpixelMode() const
@@ -801,6 +805,11 @@ bool BrushSettings::getSubpixelMode() const
 bool BrushSettings::isSquare() const
 {
 	return d->currentBrush().classic().shape == rustpile::ClassicBrushShape::SquarePixel;
+}
+
+double BrushSettings::radiusLogarithmicToPixelSize(int radiusLogarithmic)
+{
+	return std::exp(radiusLogarithmic / 100.0 - 2.0);
 }
 
 }

--- a/src/desktop/toolwidgets/brushsettings.h
+++ b/src/desktop/toolwidgets/brushsettings.h
@@ -110,6 +110,7 @@ private slots:
 private:
 	void adjustSettingVisibilities(bool softmode, bool mypaintmode);
 	void emitPresetChanges(const input::Preset *preset);
+	static double radiusLogarithmicToPixelSize(int radiusLogarithmic);
 
 	struct Private;
 	Private *d;

--- a/src/desktop/ui/brushdock.ui
+++ b/src/desktop/ui/brushdock.ui
@@ -298,19 +298,6 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="2">
-      <widget class="QSpinBox" name="paintModeBox">
-       <property name="suffix">
-        <string>%</string>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>100</number>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="hardnessLabel">
        <property name="text">
@@ -476,13 +463,6 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="paintModeLabel">
-       <property name="text">
-        <string>Pigment:</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="3">
       <widget class="widgets::GroupedToolButton" name="pressureOpacity">
        <property name="toolTip">
@@ -536,19 +516,6 @@
        </property>
        <property name="value">
         <number>0</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QSlider" name="paintModeSlider">
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>100</number>
        </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -887,38 +854,6 @@
     <hint type="destinationlabel">
      <x>154</x>
      <y>275</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>paintModeBox</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>paintModeSlider</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>264</x>
-     <y>301</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>154</x>
-     <y>301</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>paintModeSlider</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>paintModeBox</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>154</x>
-     <y>301</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>264</x>
-     <y>301</y>
     </hint>
    </hints>
   </connection>

--- a/src/desktop/widgets/brushpreview.cpp
+++ b/src/desktop/widgets/brushpreview.cpp
@@ -124,13 +124,16 @@ void BrushPreview::updatePreview()
 		m_preview = QPixmap(size);
 	}
 
-	m_brush.renderPreview(m_previewcanvas, m_shape);
+	int dabCount = m_brush.renderPreview(m_previewcanvas, m_shape);
 	if(m_shape == rustpile::BrushPreviewShape::FloodFill || m_shape == rustpile::BrushPreviewShape::FloodErase) {
 		rustpile::Color color = m_brush.color();
 		if(m_shape == rustpile::BrushPreviewShape::FloodErase) {
 			color.a = 0;
 		}
 		rustpile::brushpreview_floodfill(m_previewcanvas, &color, m_fillTolerance / 255.0, m_fillExpansion, m_underFill);
+		setToolTip(QString());
+	} else {
+		this->setToolTip(tr("%1 brush dab(s) drawn").arg(dabCount));
 	}
 
 	QPainter p(&m_preview);

--- a/src/dpcore/examples/brush_strokes.rs
+++ b/src/dpcore/examples/brush_strokes.rs
@@ -67,8 +67,8 @@ fn main() {
 
     // Pixel brush straight line
     painter.set_classicbrush(ClassicBrush::default());
-    painter.stroke_to(10.0, 140.0, 1.0, 0.0, 0.0, 0, None);
-    painter.stroke_to(512.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(10.0, 140.0, 1.0, 0.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(512.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0.0, 0, None);
     painter.end_stroke();
     painter.take_dabs(1).iter().for_each(|d| {
         canvas.receive_message(d);
@@ -101,6 +101,7 @@ fn main() {
         1.0,
         0.0,
         0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -108,6 +109,7 @@ fn main() {
         30.0,
         200.0,
         1.0,
+        0.0,
         0.0,
         0.0,
         0,
@@ -155,8 +157,8 @@ fn main() {
         shape: ClassicBrushShape::RoundSoft,
         ..ClassicBrush::default()
     });
-    painter.stroke_to(522.0, 140.0, 1.0, 0.0, 0.0, 0, None);
-    painter.stroke_to(1024.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(522.0, 140.0, 1.0, 0.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(1024.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0.0, 0, None);
     painter.end_stroke();
     painter.take_dabs(1).iter().for_each(|d| {
         canvas.receive_message(d);
@@ -191,6 +193,7 @@ fn main() {
         1.0,
         0.0,
         0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -198,6 +201,7 @@ fn main() {
         542.0,
         200.0,
         1.0,
+        0.0,
         0.0,
         0.0,
         0,
@@ -222,7 +226,7 @@ fn draw_wavy_line(
     while x < width {
         let y = (x / width * 3.141 * 4.0).sin() * amplitude;
         let p = (x / width * 3.141).sin();
-        brush.stroke_to(start_x + x, start_y + y, p, 0.0, 0.0, 0, None);
+        brush.stroke_to(start_x + x, start_y + y, p, 0.0, 0.0, 0.0, 0, None);
         x += 1.0;
     }
     brush.end_stroke();

--- a/src/dpcore/examples/brush_strokes.rs
+++ b/src/dpcore/examples/brush_strokes.rs
@@ -67,8 +67,8 @@ fn main() {
 
     // Pixel brush straight line
     painter.set_classicbrush(ClassicBrush::default());
-    painter.stroke_to(10.0, 140.0, 1.0, 0, None);
-    painter.stroke_to(512.0 - 20.0, 150.0, 1.0, 0, None);
+    painter.stroke_to(10.0, 140.0, 1.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(512.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0, None);
     painter.end_stroke();
     painter.take_dabs(1).iter().for_each(|d| {
         canvas.receive_message(d);
@@ -99,6 +99,8 @@ fn main() {
         30.0,
         10.0,
         1.0,
+        0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -106,6 +108,8 @@ fn main() {
         30.0,
         200.0,
         1.0,
+        0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -151,8 +155,8 @@ fn main() {
         shape: ClassicBrushShape::RoundSoft,
         ..ClassicBrush::default()
     });
-    painter.stroke_to(522.0, 140.0, 1.0, 0, None);
-    painter.stroke_to(1024.0 - 20.0, 150.0, 1.0, 0, None);
+    painter.stroke_to(522.0, 140.0, 1.0, 0.0, 0.0, 0, None);
+    painter.stroke_to(1024.0 - 20.0, 150.0, 1.0, 0.0, 0.0, 0, None);
     painter.end_stroke();
     painter.take_dabs(1).iter().for_each(|d| {
         canvas.receive_message(d);
@@ -185,6 +189,8 @@ fn main() {
         542.0,
         10.0,
         1.0,
+        0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -192,6 +198,8 @@ fn main() {
         542.0,
         200.0,
         1.0,
+        0.0,
+        0.0,
         0,
         canvas.layerstack().root().get_bitmaplayer(0x0101),
     );
@@ -214,7 +222,7 @@ fn draw_wavy_line(
     while x < width {
         let y = (x / width * 3.141 * 4.0).sin() * amplitude;
         let p = (x / width * 3.141).sin();
-        brush.stroke_to(start_x + x, start_y + y, p, 0, None);
+        brush.stroke_to(start_x + x, start_y + y, p, 0.0, 0.0, 0, None);
         x += 1.0;
     }
     brush.end_stroke();

--- a/src/dpcore/examples/gimp_style_brush.rs
+++ b/src/dpcore/examples/gimp_style_brush.rs
@@ -109,7 +109,7 @@ fn draw_dab(
         bx,
         by,
         &brush,
-        &Color::rgb8(0, 0, 0),
+        Color::rgb8(0, 0, 0).as_pixel15(),
         Blendmode::Normal,
         BIT15_U16,
     );

--- a/src/dpcore/examples/layer_blend_dabs.rs
+++ b/src/dpcore/examples/layer_blend_dabs.rs
@@ -75,7 +75,7 @@ fn main() {
     ];
 
     let brush = BrushMask::new_round_pixel(10);
-    let dabcolor = Color::rgb8(255, 0, 0);
+    let dabcolor = Color::rgb8(255, 0, 0).as_pixel15();
 
     for (i, &mode) in modes.iter().enumerate() {
         println!("Mode: {:?}", mode);
@@ -86,7 +86,7 @@ fn main() {
                 x as i32,
                 10 + i as i32 * 15,
                 &brush,
-                &dabcolor,
+                dabcolor,
                 mode,
                 BIT15_U16,
             );

--- a/src/dpcore/examples/layer_draw_dabs.rs
+++ b/src/dpcore/examples/layer_draw_dabs.rs
@@ -28,7 +28,7 @@ mod utils;
 
 fn main() {
     let mut layer = BitmapLayer::new(0, 256, 256, Tile::new(&Color::rgb8(255, 255, 255), 0));
-    let black = Color::rgb8(0, 0, 0);
+    let black = Color::rgb8(0, 0, 0).as_pixel15();
 
     let mut x = 10;
     let mut w = 1i32;
@@ -43,7 +43,7 @@ fn main() {
             x - w / 2,
             30 - w / 2,
             &brush,
-            &black,
+            black,
             Blendmode::Normal,
             BIT15_U16,
         );
@@ -55,7 +55,7 @@ fn main() {
             x - w / 2,
             60 - w / 2 as i32,
             &brush,
-            &black,
+            black,
             Blendmode::Normal,
             BIT15_U16,
         );
@@ -68,7 +68,7 @@ fn main() {
             bx,
             by,
             &brush,
-            &black,
+            black,
             Blendmode::Normal,
             BIT15_U16,
         );
@@ -81,7 +81,7 @@ fn main() {
             bx,
             by,
             &brush,
-            &black,
+            black,
             Blendmode::Normal,
             BIT15_U16,
         );

--- a/src/dpcore/examples/layer_indirect.rs
+++ b/src/dpcore/examples/layer_indirect.rs
@@ -30,7 +30,7 @@ fn brush_stroke(layer: &mut BitmapLayer, y: i32) {
         g: 0.0,
         b: 0.0,
         a: 1.0,
-    };
+    }.as_pixel15();
 
     for x in (10..246).step_by(5) {
         let w = 16 + ((x as f32 / 40.0 * 3.14).sin() * 15.0) as i32;
@@ -41,7 +41,7 @@ fn brush_stroke(layer: &mut BitmapLayer, y: i32) {
             x - w / 2,
             y - w / 2,
             &brush,
-            &black,
+            black,
             Blendmode::Normal,
             (0.4 * BIT15_F32) as u16,
         );

--- a/src/dpcore/examples/layerstack.rs
+++ b/src/dpcore/examples/layerstack.rs
@@ -37,7 +37,7 @@ fn brush_stroke(layer: &mut BitmapLayer, y: i32, color: &Color) {
             x - w / 2,
             y - w / 2,
             &brush,
-            &color,
+            color.as_pixel15(),
             Blendmode::Normal,
             (0.4 * BIT15_F32) as u16,
         );

--- a/src/dpcore/src/brush/brushengine.rs
+++ b/src/dpcore/src/brush/brushengine.rs
@@ -89,8 +89,17 @@ impl BrushState for BrushEngine {
         self.mypaint.set_layer(layer_id);
     }
 
-    fn stroke_to(&mut self, x: f32, y: f32, p: f32, delta_msec: i64, source: Option<&BitmapLayer>) {
-        self.state().stroke_to(x, y, p, delta_msec, source);
+    fn stroke_to(
+        &mut self,
+        x: f32,
+        y: f32,
+        p: f32,
+        xt: f32,
+        yt: f32,
+        delta_msec: i64,
+        source: Option<&BitmapLayer>,
+    ) {
+        self.state().stroke_to(x, y, p, xt, yt, delta_msec, source);
     }
 
     fn end_stroke(&mut self) {

--- a/src/dpcore/src/brush/brushengine.rs
+++ b/src/dpcore/src/brush/brushengine.rs
@@ -96,10 +96,11 @@ impl BrushState for BrushEngine {
         p: f32,
         xt: f32,
         yt: f32,
+        r: f32,
         delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {
-        self.state().stroke_to(x, y, p, xt, yt, delta_msec, source);
+        self.state().stroke_to(x, y, p, xt, yt, r, delta_msec, source);
     }
 
     fn end_stroke(&mut self) {

--- a/src/dpcore/src/brush/brushstate.rs
+++ b/src/dpcore/src/brush/brushstate.rs
@@ -33,7 +33,16 @@ pub trait BrushState {
     /// If there is no active stroke, this becomes the starting point
     ///
     /// If a source layer is given, it is used as the source of color smudging pixels
-    fn stroke_to(&mut self, x: f32, y: f32, p: f32, delta_msec: i64, source: Option<&BitmapLayer>);
+    fn stroke_to(
+        &mut self,
+        x: f32,
+        y: f32,
+        p: f32,
+        xt: f32,
+        yt: f32,
+        delta_msec: i64,
+        source: Option<&BitmapLayer>,
+    );
 
     /// End the current stroke (if any)
     fn end_stroke(&mut self);

--- a/src/dpcore/src/brush/brushstate.rs
+++ b/src/dpcore/src/brush/brushstate.rs
@@ -40,6 +40,7 @@ pub trait BrushState {
         p: f32,
         xt: f32,
         yt: f32,
+        r: f32,
         delta_msec: i64,
         source: Option<&BitmapLayer>,
     );

--- a/src/dpcore/src/brush/mypaintbrushstate.rs
+++ b/src/dpcore/src/brush/mypaintbrushstate.rs
@@ -295,6 +295,7 @@ impl BrushState for MyPaintBrushState {
         p: f32,
         xt: f32,
         yt: f32,
+        r: f32,
         delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {
@@ -340,7 +341,7 @@ impl BrushState for MyPaintBrushState {
                 delta_sec,
                 1.0,
                 0.0,
-                0.0,
+                r,
             );
         }
     }

--- a/src/dpcore/src/brush/mypaintbrushstate.rs
+++ b/src/dpcore/src/brush/mypaintbrushstate.rs
@@ -240,6 +240,11 @@ impl MyPaintBrushState {
                 0.0,
             );
         }
+
+        // We don't support spectral painting (aka Pigment mode), so we'll turn
+        // that off at the source here. It's like turning the Pigment slider in
+        // MyPaint all the way to zero.
+        self.set_base_value(c::MyPaintBrushSetting_MYPAINT_BRUSH_SETTING_PAINT_MODE, 0.0);
     }
 }
 

--- a/src/dpcore/src/brush/mypaintbrushstate.rs
+++ b/src/dpcore/src/brush/mypaintbrushstate.rs
@@ -288,7 +288,16 @@ impl BrushState for MyPaintBrushState {
         self.target.layer_id = layer_id;
     }
 
-    fn stroke_to(&mut self, x: f32, y: f32, p: f32, delta_msec: i64, source: Option<&BitmapLayer>) {
+    fn stroke_to(
+        &mut self,
+        x: f32,
+        y: f32,
+        p: f32,
+        xt: f32,
+        yt: f32,
+        delta_msec: i64,
+        source: Option<&BitmapLayer>,
+    ) {
         let mut surface = MyPaintSurface::new(source, &mut self.target);
         if !self.in_progress {
             self.in_progress = true;
@@ -326,8 +335,8 @@ impl BrushState for MyPaintBrushState {
                 x,
                 y,
                 p,
-                0.0,
-                0.0,
+                xt,
+                yt,
                 delta_sec,
                 1.0,
                 0.0,

--- a/src/dpcore/src/brush/mypaintsurface.rs
+++ b/src/dpcore/src/brush/mypaintsurface.rs
@@ -193,22 +193,29 @@ impl<'a> MyPaintSurface<'a> {
         lock_alpha: f32,
         colorize: f32,
     ) -> bool {
-        self.target.add_dab(
-            x,
-            y,
-            radius,
-            hardness,
-            opaque,
-            color_r,
-            color_g,
-            color_b,
-            alpha_eraser,
-            aspect_ratio,
-            angle,
-            lock_alpha,
-            colorize,
-        );
-        true
+        // A radius less than 0.1 pixels is infinitesimally small. A hardness or
+        // opacity of zero means the mask is completely blank. Disregard the dab
+        // in those cases. MyPaint uses the same logic for this.
+        if radius >= 0.1 && hardness > 0.0 && opaque > 0.0 {
+            self.target.add_dab(
+                x,
+                y,
+                radius,
+                hardness,
+                opaque,
+                color_r,
+                color_g,
+                color_b,
+                alpha_eraser,
+                aspect_ratio,
+                angle,
+                lock_alpha,
+                colorize,
+            );
+            true
+        } else {
+            false
+        }
     }
 
     fn get_color(&mut self, x: f32, y: f32, radius: f32) -> Color {

--- a/src/dpcore/src/brush/pixelbrushstate.rs
+++ b/src/dpcore/src/brush/pixelbrushstate.rs
@@ -157,6 +157,7 @@ impl BrushState for PixelBrushState {
         p: f32,
         _xt: f32,
         _yt: f32,
+        _r: f32,
         _delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {

--- a/src/dpcore/src/brush/pixelbrushstate.rs
+++ b/src/dpcore/src/brush/pixelbrushstate.rs
@@ -155,6 +155,8 @@ impl BrushState for PixelBrushState {
         x: f32,
         y: f32,
         p: f32,
+        _xt: f32,
+        _yt: f32,
         _delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {

--- a/src/dpcore/src/brush/softbrushstate.rs
+++ b/src/dpcore/src/brush/softbrushstate.rs
@@ -147,6 +147,8 @@ impl BrushState for SoftBrushState {
         x: f32,
         y: f32,
         p: f32,
+        _xt: f32,
+        _yt: f32,
         _delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {

--- a/src/dpcore/src/brush/softbrushstate.rs
+++ b/src/dpcore/src/brush/softbrushstate.rs
@@ -149,6 +149,7 @@ impl BrushState for SoftBrushState {
         p: f32,
         _xt: f32,
         _yt: f32,
+        _r: f32,
         _delta_msec: i64,
         source: Option<&BitmapLayer>,
     ) {

--- a/src/dpcore/src/protocol/message.rs
+++ b/src/dpcore/src/protocol/message.rs
@@ -1240,20 +1240,26 @@ pub struct DrawDabsMyPaintMessage {
     pub y: i32,
     pub color: u32,
     pub lock_alpha: u8,
+    pub colorize: u8,
+    pub posterize: u8,
+    pub posterize_num: u8,
     pub dabs: Vec<MyPaintDab>,
 }
 
 impl DrawDabsMyPaintMessage {
-    pub const MAX_MYPAINTDABS: usize = 8190;
+    pub const MAX_MYPAINTDABS: usize = 8189;
 
     fn deserialize(reader: &mut MessageReader) -> Result<Self, DeserializationError> {
-        reader.validate(23, 65535)?;
+        reader.validate(26, 65530)?;
 
         let layer = reader.read::<u16>();
         let x = reader.read::<i32>();
         let y = reader.read::<i32>();
         let color = reader.read::<u32>();
         let lock_alpha = reader.read::<u8>();
+        let colorize = reader.read::<u8>();
+        let posterize = reader.read::<u8>();
+        let posterize_num = reader.read::<u8>();
         let mut dabs = Vec::<MyPaintDab>::with_capacity(reader.remaining() / 8);
         while reader.remaining() > 0 {
             let x = reader.read::<i8>();
@@ -1279,17 +1285,23 @@ impl DrawDabsMyPaintMessage {
             y,
             color,
             lock_alpha,
+            colorize,
+            posterize,
+            posterize_num,
             dabs,
         })
     }
 
     fn serialize(&self, w: &mut MessageWriter, user_id: u8) {
-        w.write_header(151, user_id, 15 + (self.dabs.len() * 8));
+        w.write_header(151, user_id, 18 + (self.dabs.len() * 8));
         w.write(self.layer);
         w.write(self.x);
         w.write(self.y);
         w.write(self.color);
         w.write(self.lock_alpha);
+        w.write(self.colorize);
+        w.write(self.posterize);
+        w.write(self.posterize_num);
         for item in self.dabs.iter() {
             w.write(item.x);
             w.write(item.y);
@@ -1319,6 +1331,9 @@ impl DrawDabsMyPaintMessage {
             .set("y", (self.y as f64 / 4.0).to_string())
             .set_argb32("color", self.color)
             .set("lock_alpha", self.lock_alpha.to_string())
+            .set("colorize", self.colorize.to_string())
+            .set("posterize", self.posterize.to_string())
+            .set("posterize_num", self.posterize_num.to_string())
             .set_dabs(dabs)
     }
 
@@ -1345,6 +1360,9 @@ impl DrawDabsMyPaintMessage {
             y: (tm.get_f64("y") * 4.0) as i32,
             color: tm.get_argb32("color"),
             lock_alpha: tm.get_u8("lock_alpha"),
+            colorize: tm.get_u8("colorize"),
+            posterize: tm.get_u8("posterize"),
+            posterize_num: tm.get_u8("posterize_num"),
             dabs: dab_structs,
         }
     }

--- a/src/dpcore/src/protocol/protocol.yaml
+++ b/src/dpcore/src/protocol/protocol.yaml
@@ -634,6 +634,9 @@ DrawDabsMyPaint:
         - y i32: div4
         - color argb32
         - lock_alpha u8
+        - colorize u8
+        - posterize u8
+        - posterize_num u8
         - dabs struct:
           name: MyPaintDab
           fields:

--- a/src/libclient/brushes/brush.cpp
+++ b/src/libclient/brushes/brush.cpp
@@ -539,12 +539,12 @@ void ActiveBrush::setInBrushEngine(rustpile::BrushEngine *be, uint16_t layer, bo
 	}
 }
 
-void ActiveBrush::renderPreview(rustpile::BrushPreview *bp, rustpile::BrushPreviewShape shape) const
+int ActiveBrush::renderPreview(rustpile::BrushPreview *bp, rustpile::BrushPreviewShape shape) const
 {
 	if(m_activeType == CLASSIC) {
-		rustpile::brushpreview_render_classic(bp, &m_classic, shape);
+		return rustpile::brushpreview_render_classic(bp, &m_classic, shape);
 	} else {
-		rustpile::brushpreview_render_mypaint(
+		return rustpile::brushpreview_render_mypaint(
 			bp, &m_myPaint.constBrush(), &m_myPaint.constSettings(), shape);
 	}
 }

--- a/src/libclient/brushes/brush.h
+++ b/src/libclient/brushes/brush.h
@@ -121,7 +121,8 @@ public:
 	QPixmap presetThumbnail() const;
 
 	void setInBrushEngine(rustpile::BrushEngine *be, uint16_t layer, bool freehand = true) const;
-	void renderPreview(rustpile::BrushPreview *bp, rustpile::BrushPreviewShape shape) const;
+	// Returns the number of dabs drawn in the preview.
+	int renderPreview(rustpile::BrushPreview *bp, rustpile::BrushPreviewShape shape) const;
 
 private:
 	ActiveType m_activeType;

--- a/src/libclient/brushes/brushpresetmodel.cpp
+++ b/src/libclient/brushes/brushpresetmodel.cpp
@@ -393,7 +393,15 @@ private:
 	QString createDb()
 	{
 		QString databasePath = utils::paths::writablePath("brushpresets.db");
-		if(!QFileInfo(databasePath).exists()) {
+		QFileInfo fileInfo(databasePath);
+
+		QString dirName = fileInfo.canonicalPath();
+		if(!QDir().mkpath(dirName)) {
+			qWarning("Failed to create brush preset database parent directory '%s'",
+				qPrintable(dirName));
+		}
+
+		if(!fileInfo.exists()) {
 			QString initialPath = utils::paths::locateDataFile("initialbrushpresets.db");
 			if(initialPath.isEmpty()) {
 				qWarning("No initial brush preset database found");

--- a/src/libclient/canvas/point.h
+++ b/src/libclient/canvas/point.h
@@ -26,26 +26,26 @@
 namespace canvas {
 
 /**
- * @brief An extended point class that includes pressure information.
+ * @brief An extended point class that includes pressure and tilt information.
  */
 class Point : public QPointF {
 public:
-	Point() : QPointF(), m_p(1) {}
+	Point() : QPointF(), m_p(1), m_xt(0), m_yt(0) {}
 
-	Point(qreal x, qreal y, qreal p)
-		: QPointF(x, y), m_p(p)
+	Point(qreal x, qreal y, qreal p, qreal xt = 0.0, qreal yt = 0.0)
+		: QPointF(x, y), m_p(p), m_xt(xt), m_yt(yt)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
 
-	Point(const QPointF& point, qreal p)
-		: QPointF(point), m_p(p)
+	Point(const QPointF& point, qreal p, qreal xt = 0.0, qreal yt = 0.0)
+		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
 
-	Point(const QPoint& point, qreal p)
-		: QPointF(point), m_p(p)
+	Point(const QPoint& point, qreal p, qreal xt = 0.0, qreal yt = 0.0)
+		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
@@ -53,11 +53,20 @@ public:
 	//! Get the pressure value for this point
 	qreal pressure() const { return m_p; }
 
-	//! Get a reference to the pressure value of this point
-	qreal &rpressure() { return m_p; }
-
 	//! Set this point's pressure value
 	void setPressure(qreal p) { Q_ASSERT(p>=0 && p<=1); m_p = p; }
+
+	//! Get pen x axis tilt in degrees for this point
+	qreal xtilt() const { return m_xt; }
+
+	//! Set this point's x axis tilt value in degrees
+	void setXtilt(qreal xt) { m_xt = xt; }
+
+	//! Get pen y axis tilt in degrees for this point
+	qreal ytilt() const { return m_yt; }
+
+	//! Set this point's y axis tilt value in degrees
+	void setYtilt(qreal yt) { m_yt = yt; }
 
 	//! Compare two points at subpixel resolution
 	static bool roughlySame(const QPointF& p1, const QPointF &p2) {
@@ -85,18 +94,9 @@ public:
 
 private:
 	qreal m_p;
+	qreal m_xt;
+	qreal m_yt;
 };
-
-static inline Point operator-(const Point& p1, const QPointF& p2)
-{
-	return Point(p1.x()-p2.x(), p1.y()-p2.y(), p1.pressure());
-}
-
-static inline Point operator+(const Point& p1, const QPointF& p2)
-{
-	return Point(p1.x()+p2.x(), p1.y()+p2.y(), p1.pressure());
-}
-
 
 typedef QVector<Point> PointVector;
 

--- a/src/libclient/canvas/point.h
+++ b/src/libclient/canvas/point.h
@@ -30,22 +30,22 @@ namespace canvas {
  */
 class Point : public QPointF {
 public:
-	Point() : QPointF(), m_p(1), m_xt(0), m_yt(0) {}
+	Point() : QPointF(), m_p(1), m_xt(0), m_yt(0), m_r(0) {}
 
-	Point(qreal x, qreal y, qreal p, qreal xt = 0.0, qreal yt = 0.0)
-		: QPointF(x, y), m_p(p), m_xt(xt), m_yt(yt)
+	Point(qreal x, qreal y, qreal p, qreal xt = 0.0, qreal yt = 0.0, qreal r = 0.0)
+		: QPointF(x, y), m_p(p), m_xt(xt), m_yt(yt), m_r(r)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
 
-	Point(const QPointF& point, qreal p, qreal xt = 0.0, qreal yt = 0.0)
-		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt)
+	Point(const QPointF& point, qreal p, qreal xt = 0.0, qreal yt = 0.0, qreal r = 0.0)
+		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt), m_r(r)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
 
-	Point(const QPoint& point, qreal p, qreal xt = 0.0, qreal yt = 0.0)
-		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt)
+	Point(const QPoint& point, qreal p, qreal xt = 0.0, qreal yt = 0.0, qreal r = 0.0)
+		: QPointF(point), m_p(p), m_xt(xt), m_yt(yt), m_r(r)
 	{
 		Q_ASSERT(p>=0 && p<=1);
 	}
@@ -67,6 +67,12 @@ public:
 
 	//! Set this point's y axis tilt value in degrees
 	void setYtilt(qreal yt) { m_yt = yt; }
+
+	//! Get pen barrel rotation in degrees for this point
+	qreal rotation() const { return m_r; }
+
+	//! Set this point's barrel rotation value in degrees
+	void setRotation(qreal r) { m_r = r; }
 
 	//! Compare two points at subpixel resolution
 	static bool roughlySame(const QPointF& p1, const QPointF &p2) {
@@ -96,6 +102,7 @@ private:
 	qreal m_p;
 	qreal m_xt;
 	qreal m_yt;
+	qreal m_r;
 };
 
 typedef QVector<Point> PointVector;

--- a/src/libclient/tools/beziertool.cpp
+++ b/src/libclient/tools/beziertool.cpp
@@ -119,7 +119,7 @@ void BezierTool::finishMultipart()
 
 		const auto pv = calculateBezierCurve();
 		for(const auto &p : pv) {
-			rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
+			rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), p.rotation(), 10, engine, owner.activeLayer());
 		}
 		rustpile::brushengine_end_stroke(brushengine);
 
@@ -210,7 +210,7 @@ void BezierTool::updatePreview()
 	auto engine = owner.model()->paintEngine()->engine();
 
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), p.rotation(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 

--- a/src/libclient/tools/beziertool.cpp
+++ b/src/libclient/tools/beziertool.cpp
@@ -119,7 +119,7 @@ void BezierTool::finishMultipart()
 
 		const auto pv = calculateBezierCurve();
 		for(const auto &p : pv) {
-			rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), 10, engine, owner.activeLayer());
+			rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
 		}
 		rustpile::brushengine_end_stroke(brushengine);
 
@@ -210,7 +210,7 @@ void BezierTool::updatePreview()
 	auto engine = owner.model()->paintEngine()->engine();
 
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 

--- a/src/libclient/tools/freehand.cpp
+++ b/src/libclient/tools/freehand.cpp
@@ -78,6 +78,8 @@ void Freehand::motion(const canvas::Point& point, bool constrain, bool center)
 			m_start.x(),
 			m_start.y(),
 			qMin(m_start.pressure(), point.pressure()),
+			m_start.xtilt(),
+			m_start.ytilt(),
 			0,
 			owner.model()->paintEngine()->engine(),
 			owner.activeLayer()
@@ -93,6 +95,8 @@ void Freehand::motion(const canvas::Point& point, bool constrain, bool center)
 		point.x(),
 		point.y(),
 		point.pressure(),
+		point.xtilt(),
+		point.ytilt(),
 		deltaMsec,
 		owner.model()->paintEngine()->engine(),
 		owner.activeLayer()
@@ -120,6 +124,8 @@ void Freehand::end()
 				m_start.x(),
 				m_start.y(),
 				m_start.pressure(),
+				m_start.xtilt(),
+				m_start.ytilt(),
 				QDateTime::currentMSecsSinceEpoch(),
 				nullptr,
 				0

--- a/src/libclient/tools/freehand.cpp
+++ b/src/libclient/tools/freehand.cpp
@@ -80,6 +80,7 @@ void Freehand::motion(const canvas::Point& point, bool constrain, bool center)
 			qMin(m_start.pressure(), point.pressure()),
 			m_start.xtilt(),
 			m_start.ytilt(),
+			m_start.rotation(),
 			0,
 			owner.model()->paintEngine()->engine(),
 			owner.activeLayer()
@@ -97,6 +98,7 @@ void Freehand::motion(const canvas::Point& point, bool constrain, bool center)
 		point.pressure(),
 		point.xtilt(),
 		point.ytilt(),
+		point.rotation(),
 		deltaMsec,
 		owner.model()->paintEngine()->engine(),
 		owner.activeLayer()
@@ -126,6 +128,7 @@ void Freehand::end()
 				m_start.pressure(),
 				m_start.xtilt(),
 				m_start.ytilt(),
+				m_start.rotation(),
 				QDateTime::currentMSecsSinceEpoch(),
 				nullptr,
 				0

--- a/src/libclient/tools/shapetools.cpp
+++ b/src/libclient/tools/shapetools.cpp
@@ -87,7 +87,7 @@ void ShapeTool::end()
 
 	const auto pv = pointVector();
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 
@@ -114,7 +114,7 @@ void ShapeTool::updatePreview()
 	Q_ASSERT(pv.size()>1);
 
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 

--- a/src/libclient/tools/shapetools.cpp
+++ b/src/libclient/tools/shapetools.cpp
@@ -87,7 +87,7 @@ void ShapeTool::end()
 
 	const auto pv = pointVector();
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), p.rotation(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 
@@ -114,7 +114,7 @@ void ShapeTool::updatePreview()
 	Q_ASSERT(pv.size()>1);
 
 	for(const auto &p : pv) {
-		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), 10, engine, owner.activeLayer());
+		rustpile::brushengine_stroke_to(brushengine, p.x(), p.y(), p.pressure(), p.xtilt(), p.ytilt(), p.rotation(), 10, engine, owner.activeLayer());
 	}
 	rustpile::brushengine_end_stroke(brushengine);
 

--- a/src/libclient/tools/strokesmoother.cpp
+++ b/src/libclient/tools/strokesmoother.cpp
@@ -81,17 +81,23 @@ canvas::Point StrokeSmoother::smoothPoint() const
 	auto p = at(0);
 
 	qreal pressure = p.pressure();
+	qreal xtilt = p.xtilt();
+	qreal ytilt = p.ytilt();
 	for(int i=1;i<_points.size();++i) {
 		const auto pi = at(i);
 		p.rx() += pi.x();
 		p.ry() += pi.y();
 		pressure += pi.pressure();
+		xtilt += pi.xtilt();
+		ytilt += pi.ytilt();
 	}
 
 	const qreal c = _points.size();
 	p.rx() /= c;
 	p.ry() /= c;
 	p.setPressure(pressure / c);
+	p.setXtilt(xtilt / c);
+	p.setYtilt(ytilt / c);
 
 	return p;
 }

--- a/src/libclient/tools/strokesmoother.cpp
+++ b/src/libclient/tools/strokesmoother.cpp
@@ -83,6 +83,7 @@ canvas::Point StrokeSmoother::smoothPoint() const
 	qreal pressure = p.pressure();
 	qreal xtilt = p.xtilt();
 	qreal ytilt = p.ytilt();
+	qreal rotation = p.rotation();
 	for(int i=1;i<_points.size();++i) {
 		const auto pi = at(i);
 		p.rx() += pi.x();
@@ -90,6 +91,7 @@ canvas::Point StrokeSmoother::smoothPoint() const
 		pressure += pi.pressure();
 		xtilt += pi.xtilt();
 		ytilt += pi.ytilt();
+		rotation += pi.rotation();
 	}
 
 	const qreal c = _points.size();
@@ -98,6 +100,7 @@ canvas::Point StrokeSmoother::smoothPoint() const
 	p.setPressure(pressure / c);
 	p.setXtilt(xtilt / c);
 	p.setYtilt(ytilt / c);
+	p.setRotation(rotation / c);
 
 	return p;
 }

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -47,7 +47,7 @@ constexpr static const uintptr_t DrawDabsClassicMessage_MAX_CLASSICDABS = 10920;
 
 constexpr static const uintptr_t DrawDabsPixelMessage_MAX_PIXELDABS = 16380;
 
-constexpr static const uintptr_t DrawDabsMyPaintMessage_MAX_MYPAINTDABS = 8190;
+constexpr static const uintptr_t DrawDabsMyPaintMessage_MAX_MYPAINTDABS = 8189;
 
 enum class AnimationExportMode {
   Gif,

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -438,14 +438,14 @@ BrushPreview *brushpreview_new(uint32_t width, uint32_t height);
 
 void brushpreview_free(BrushPreview *bp);
 
-void brushpreview_render_classic(BrushPreview *bp,
-                                 const ClassicBrush *brush,
-                                 BrushPreviewShape shape);
+int32_t brushpreview_render_classic(BrushPreview *bp,
+                                    const ClassicBrush *brush,
+                                    BrushPreviewShape shape);
 
-void brushpreview_render_mypaint(BrushPreview *bp,
-                                 const MyPaintBrush *brush,
-                                 const MyPaintSettings *settings,
-                                 BrushPreviewShape shape);
+int32_t brushpreview_render_mypaint(BrushPreview *bp,
+                                    const MyPaintBrush *brush,
+                                    const MyPaintSettings *settings,
+                                    BrushPreviewShape shape);
 
 void brushpreview_floodfill(BrushPreview *bp,
                             const Color *color,

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -415,6 +415,8 @@ void brushengine_stroke_to(BrushEngine *be,
                            float x,
                            float y,
                            float p,
+                           float xt,
+                           float yt,
                            int64_t delta_msec,
                            const PaintEngine *pe,
                            LayerID layer_id);

--- a/src/rustpile/rustpile.h
+++ b/src/rustpile/rustpile.h
@@ -417,6 +417,7 @@ void brushengine_stroke_to(BrushEngine *be,
                            float p,
                            float xt,
                            float yt,
+                           float r,
                            int64_t delta_msec,
                            const PaintEngine *pe,
                            LayerID layer_id);

--- a/src/rustpile/src/brushes_ffi.rs
+++ b/src/rustpile/src/brushes_ffi.rs
@@ -50,6 +50,7 @@ pub extern "C" fn brushengine_stroke_to(
     p: f32,
     xt: f32,
     yt: f32,
+    r: f32,
     delta_msec: i64,
     pe: Option<&PaintEngine>,
     layer_id: LayerID,
@@ -62,11 +63,12 @@ pub extern "C" fn brushengine_stroke_to(
             p,
             xt,
             yt,
+            r,
             delta_msec,
             vc.layerstack.root().get_bitmaplayer(layer_id),
         );
     } else {
-        be.stroke_to(x, y, p, xt, yt, delta_msec, None);
+        be.stroke_to(x, y, p, xt, yt, r, delta_msec, None);
     }
 }
 

--- a/src/rustpile/src/brushes_ffi.rs
+++ b/src/rustpile/src/brushes_ffi.rs
@@ -48,6 +48,8 @@ pub extern "C" fn brushengine_stroke_to(
     x: f32,
     y: f32,
     p: f32,
+    xt: f32,
+    yt: f32,
     delta_msec: i64,
     pe: Option<&PaintEngine>,
     layer_id: LayerID,
@@ -58,11 +60,13 @@ pub extern "C" fn brushengine_stroke_to(
             x,
             y,
             p,
+            xt,
+            yt,
             delta_msec,
             vc.layerstack.root().get_bitmaplayer(layer_id),
         );
     } else {
-        be.stroke_to(x, y, p, delta_msec, None);
+        be.stroke_to(x, y, p, xt, yt, delta_msec, None);
     }
 }
 

--- a/src/rustpile/src/brushpreview.rs
+++ b/src/rustpile/src/brushpreview.rs
@@ -71,7 +71,8 @@ impl BrushPreview {
         smudge: bool,
         mode: Blendmode,
         set_engine_brush: SetEngineBrushFn,
-    ) where
+    ) -> usize
+    where
         SetEngineBrushFn: FnOnce(&mut BrushEngine, Option<Color>),
     {
         // Prepare background and foreground colors
@@ -235,24 +236,34 @@ impl BrushPreview {
         let mut brushcache = ClassicBrushCache::new();
 
         let dabs = painter.take_dabs(1);
+        let mut dab_count = 0;
         for dab in dabs {
             match dab {
                 CommandMessage::DrawDabsClassic(_, m) => {
-                    brushes::drawdabs_classic(layer, 1, &m, &mut brushcache)
+                    brushes::drawdabs_classic(layer, 1, &m, &mut brushcache);
+                    dab_count += m.dabs.len();
                 }
-                CommandMessage::DrawDabsPixel(_, m) => brushes::drawdabs_pixel(layer, 1, &m, false),
+                CommandMessage::DrawDabsPixel(_, m) => {
+                    brushes::drawdabs_pixel(layer, 1, &m, false);
+                    dab_count += m.dabs.len();
+                }
                 CommandMessage::DrawDabsPixelSquare(_, m) => {
-                    brushes::drawdabs_pixel(layer, 1, &m, true)
+                    brushes::drawdabs_pixel(layer, 1, &m, true);
+                    dab_count += m.dabs.len();
                 }
-                CommandMessage::DrawDabsMyPaint(_, m) => brushes::drawdabs_mypaint(layer, 1, &m),
+                CommandMessage::DrawDabsMyPaint(_, m) => {
+                    brushes::drawdabs_mypaint(layer, 1, &m);
+                    dab_count += m.dabs.len();
+                }
                 _ => unimplemented!(),
             };
         }
 
         editlayer::merge_sublayer(layer, 1);
+        dab_count
     }
 
-    pub fn render_classic(&mut self, brush: &ClassicBrush, shape: BrushPreviewShape) {
+    pub fn render_classic(&mut self, brush: &ClassicBrush, shape: BrushPreviewShape) -> usize {
         self.render(
             shape,
             brush.color,
@@ -266,7 +277,7 @@ impl BrushPreview {
                 }
                 painter.set_classicbrush(cloned_brush);
             },
-        );
+        )
     }
 
     pub fn render_mypaint(
@@ -274,7 +285,7 @@ impl BrushPreview {
         brush: &MyPaintBrush,
         settings: &MyPaintSettings,
         shape: BrushPreviewShape,
-    ) {
+    ) -> usize {
         self.render(
             shape,
             brush.color,

--- a/src/rustpile/src/brushpreview.rs
+++ b/src/rustpile/src/brushpreview.rs
@@ -169,14 +169,13 @@ impl BrushPreview {
                 let mut hue = 0.0;
                 let dabmask = BrushMask::new_round_pixel(d as u32);
                 for x in (x0..x1).step_by(step as usize) {
-                    let color = Color::from_hsv(hue, 0.62, 0.86);
                     editlayer::draw_brush_dab(
                         layer,
                         1,
                         x - d / 2,
                         h / 2 - d / 2,
                         &dabmask,
-                        &color,
+                        Color::from_hsv(hue, 0.62, 0.86).as_pixel15(),
                         Blendmode::Normal,
                         BIT15_U16,
                     );

--- a/src/rustpile/src/brushpreview.rs
+++ b/src/rustpile/src/brushpreview.rs
@@ -228,7 +228,7 @@ impl BrushPreview {
         let mut painter = BrushEngine::new();
         set_engine_brush(&mut painter, brush_color);
         for p in points {
-            painter.stroke_to(p.0, p.1, p.2, 20, Some(layer));
+            painter.stroke_to(p.0, p.1, p.2, 0.0, 0.0, 20, Some(layer));
         }
         painter.end_stroke();
 

--- a/src/rustpile/src/brushpreview.rs
+++ b/src/rustpile/src/brushpreview.rs
@@ -228,7 +228,7 @@ impl BrushPreview {
         let mut painter = BrushEngine::new();
         set_engine_brush(&mut painter, brush_color);
         for p in points {
-            painter.stroke_to(p.0, p.1, p.2, 0.0, 0.0, 20, Some(layer));
+            painter.stroke_to(p.0, p.1, p.2, 0.0, 0.0, 0.0, 20, Some(layer));
         }
         painter.end_stroke();
 

--- a/src/rustpile/src/brushpreview_ffi.rs
+++ b/src/rustpile/src/brushpreview_ffi.rs
@@ -45,8 +45,8 @@ pub extern "C" fn brushpreview_render_classic(
     bp: &mut BrushPreview,
     brush: &ClassicBrush,
     shape: BrushPreviewShape,
-) {
-    bp.render_classic(brush, shape);
+) -> i32 {
+    bp.render_classic(brush, shape) as i32
 }
 
 #[no_mangle]
@@ -55,8 +55,8 @@ pub extern "C" fn brushpreview_render_mypaint(
     brush: &MyPaintBrush,
     settings: &MyPaintSettings,
     shape: BrushPreviewShape,
-) {
-    bp.render_mypaint(brush, settings, shape);
+) -> i32 {
+    bp.render_mypaint(brush, settings, shape) as i32
 }
 
 #[no_mangle]


### PR DESCRIPTION
Supports colorize and posterize for MyPaint brushes. This breaks protocol, so we should probably increment the version? I'll leave that up to you.

Removes the Pigment slider, because that's spectral painting stuff, which we don't support and now force off in MyPaintBrushState. It's some weird realistic-ish color mixing thing with matrices that's really brutal on performance and cranked up really high by all MyPaint brushes by default. I don't think it's worth supporting and making everything slow for it.

Now drops dabs of infinitesimal size, opacity or hardness, like MyPaint does it.

Makes the freehand tool actually use the MyPaint brush size when it's selected, before it only applied it sometimes.

And finally, supports pen tilt and barrel rotation for MyPaint brushes, for people with tablets that report that kinda thing.

Edit: and also add a tooltip to the brush preview that says how many dabs it drew, to help users get _some_ kinda idea of how "heavy" a brush is. Some of them draw orders of magnitude more dabs than a classic brush, causing resets really fast.

Edit²: create the parent directory of the brush presets database if it doesn't exist yet. This happens if it's the first time a user has ever run Drawpile.