### PR TITLE
Allow newlines in chat

### DIFF
--- a/src/desktop/chat/chatlineedit.cpp
+++ b/src/desktop/chat/chatlineedit.cpp
@@ -21,8 +21,9 @@
 #include "chatlineedit.h"
 
 ChatLineEdit::ChatLineEdit(QWidget *parent) :
-	QLineEdit(parent), _historypos(0)
+	QPlainTextEdit(parent), _historypos(0)
 {
+	setFixedHeight(60);
 }
 
 void ChatLineEdit::pushHistory(const QString &text)
@@ -44,34 +45,34 @@ void ChatLineEdit::keyPressEvent(QKeyEvent *event)
 	if(event->key() == Qt::Key_Up) {
 		if(_historypos>0) {
 			if(_historypos==_history.count())
-				_current = text();
+				_current = toPlainText();
 			--_historypos;
-			setText(_history[_historypos]);
+			setPlainText(_history[_historypos]);
 		}
 	} else if(event->key() == Qt::Key_Down) {
 		if(_historypos<_history.count()-1) {
 			++_historypos;
-			setText(_history[_historypos]);
+			setPlainText(_history[_historypos]);
 		} else if(_historypos==_history.count()-1) {
 			++_historypos;
-			setText(_current);
+			setPlainText(_current);
 		}
-	} else if(event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+	} else if((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) && !(event->modifiers() & Qt::ShiftModifier)) {
 		QString txt = trimmedText();
 		if(!txt.isEmpty()) {
 			pushHistory(txt);
 			_historypos = _history.count();
-			setText(QString());
+			setPlainText(QString());
 			emit returnPressed(txt);
 		}
 	} else {
-		QLineEdit::keyPressEvent(event);
+		QPlainTextEdit::keyPressEvent(event);
 	}
 }
 
 QString ChatLineEdit::trimmedText() const
 {
-	QString str = text();
+	QString str = toPlainText();
 
 	// Remove trailing whitespace
 	int chop = str.length();

--- a/src/desktop/chat/chatlineedit.h
+++ b/src/desktop/chat/chatlineedit.h
@@ -20,12 +20,12 @@
 #define CHATLINEEDIT_H
 
 #include <QStringList>
-#include <QLineEdit>
+#include <QPlainTextEdit>
 
 /**
  * @brief A specialized line edit widget for chatting, with history
   */
-class ChatLineEdit : public QLineEdit
+class ChatLineEdit : public QPlainTextEdit
 {
 Q_OBJECT
 public:

--- a/src/desktop/chat/chatwidget.cpp
+++ b/src/desktop/chat/chatwidget.cpp
@@ -212,12 +212,12 @@ void ChatWidget::Private::updatePreserveModeUi()
 
 	chatbox->setStyleSheet(
 		QStringLiteral(
-		"QTextEdit, QLineEdit {"
+		"QTextEdit, QPlainTextEdit {"
 			"background-color: #232629;"
 			"border: none;"
 			"color: #eff0f1"
 		"}"
-		"QLineEdit {"
+		"QPlainTextEdit {"
 			"border-top: 1px solid %1;"
 			"padding: 4px"
 		"}"
@@ -389,7 +389,12 @@ void Chat::appendMessage(int userId, const QString &usernameSpan, const QString 
 		cursor.setPosition(b.position() + b.length() - 1);
 
 		cursor.insertHtml(QStringLiteral("<br>"));
-		cursor.insertHtml(message);
+	
+		// Using css property "white-space: pre" only works for the first message. Newlines disappear on subsequent messages.
+		// Thus the need to manually replace newlines by <br>
+		QString messageWithBr = message;
+		messageWithBr.replace("\n", "<br>");
+		cursor.insertHtml(messageWithBr);
 
 		return;
 	}


### PR DESCRIPTION
Hello, this upgrades the chat input to support newlines (by typing Shift+Enter). I've changed the chat to display said newlines by converting them to `<br>`.
![image](https://user-images.githubusercontent.com/103213068/189739474-ebb6651d-4c7e-499e-abdd-2ce5f3822cff.png)
Thank you.