### PR TITLE
Disable blend mode when folder pass through is set

### DIFF
--- a/src/desktop/ui/layerproperties.ui
+++ b/src/desktop/ui/layerproperties.ui
@@ -219,7 +219,7 @@
    <sender>passThrough</sender>
    <signal>toggled(bool)</signal>
    <receiver>blendMode</receiver>
-   <slot>setEnabled(bool)</slot>
+   <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>150</x>


### PR DESCRIPTION
I didn't invert this properly in #1036, so the logic was the wrong way round. Thanks to Rylan for finding it.