### PR TITLE
Add a forceNsfm option for the server

### DIFF
--- a/src/desktop/dialogs/sessionsettings.cpp
+++ b/src/desktop/dialogs/sessionsettings.cpp
@@ -83,7 +83,8 @@ SessionSettingsDialog::SessionSettingsDialog(Document *doc, QWidget *parent)
 		m_ui->opword->setProperty("haspass", hasPassword);
 		updatePasswordLabel(m_ui->opword);
 	});
-	connect(m_doc, &Document::sessionNsfmChanged, m_ui->nsfm, &QCheckBox::setChecked);
+	connect(m_doc, &Document::sessionNsfmChanged, this, &SessionSettingsDialog::updateNsfmCheckbox);
+	connect(m_doc, &Document::sessionForceNsfmChanged, this, &SessionSettingsDialog::updateNsfmCheckbox);
 	connect(m_doc, &Document::sessionDeputiesChanged, this, [this](bool deputies) { m_ui->deputies->setCurrentIndex(deputies ? 1 : 0); });
 	connect(m_doc, &Document::sessionMaxUserCountChanged, m_ui->maxUsers, &QSpinBox::setValue);
 	connect(m_doc, &Document::sessionResetThresholdChanged, m_ui->autoresetThreshold, &QDoubleSpinBox::setValue);
@@ -370,6 +371,17 @@ void SessionSettingsDialog::updatePasswordLabel(QLabel *label)
 		txt = txt.arg(tr("no", "password"), tr("assign", "password"));
 
 	label->setText(txt);
+}
+
+void SessionSettingsDialog::updateNsfmCheckbox(bool)
+{
+	if(m_doc->isSessionForceNsfm()) {
+		m_ui->nsfm->setEnabled(false);
+		m_ui->nsfm->setChecked(true);
+	} else {
+		m_ui->nsfm->setEnabled(true);
+		m_ui->nsfm->setChecked(m_doc->isSessionNsfm());
+	}
 }
 
 void SessionSettingsDialog::sendSessionConf()

--- a/src/desktop/dialogs/sessionsettings.h
+++ b/src/desktop/dialogs/sessionsettings.h
@@ -86,6 +86,7 @@ private slots:
 	void sendSessionConf();
 
 	void updatePasswordLabel(QLabel *label);
+	void updateNsfmCheckbox(bool);
 
 protected:
 	void showEvent(QShowEvent *event) override;

--- a/src/libclient/document.cpp
+++ b/src/libclient/document.cpp
@@ -55,6 +55,7 @@ Document::Document(QObject *parent)
 	  m_sessionPasswordProtected(false),
 	  m_sessionOpword(false),
 	  m_sessionNsfm(false),
+	  m_sessionForceNsfm(false),
 	  m_sessionDeputies(false),
 	  m_sessionMaxUserCount(0),
 	  m_sessionHistoryMaxSize(0),
@@ -236,6 +237,9 @@ void Document::onSessionConfChanged(const QJsonObject &config)
 	if(config.contains("nsfm"))
 		setSessionNsfm(config["nsfm"].toBool());
 
+	if(config.contains("forceNsfm"))
+		setSessionForceNsfm(config["forceNsfm"].toBool());
+
 	if(config.contains("deputies"))
 		setSessionDeputies(config["deputies"].toBool());
 
@@ -382,6 +386,14 @@ void Document::setSessionNsfm(bool nsfm)
 	if(m_sessionNsfm != nsfm) {
 		m_sessionNsfm = nsfm;
 		emit sessionNsfmChanged(nsfm);
+	}
+}
+
+void Document::setSessionForceNsfm(bool forceNsfm)
+{
+	if(m_sessionForceNsfm != forceNsfm) {
+		m_sessionForceNsfm = forceNsfm;
+		emit sessionForceNsfmChanged(forceNsfm);
 	}
 }
 

--- a/src/libclient/document.h
+++ b/src/libclient/document.h
@@ -72,6 +72,7 @@ class Document : public QObject
 	Q_PROPERTY(bool sessionPasswordProtected READ isSessionPasswordProtected NOTIFY sessionPasswordChanged)
 	Q_PROPERTY(bool sessionHasOpword READ isSessionOpword NOTIFY sessionOpwordChanged)
 	Q_PROPERTY(bool sessionNsfm READ isSessionNsfm NOTIFY sessionNsfmChanged)
+	Q_PROPERTY(bool sessionForceNsfm READ isSessionForceNsfm NOTIFY sessionForceNsfmChanged)
 	Q_PROPERTY(bool sessionDeputies READ isSessionDeputies NOTIFY sessionDeputiesChanged)
 	Q_PROPERTY(int sessionMaxUserCount READ sessionMaxUserCount NOTIFY sessionMaxUserCountChanged)
 	Q_PROPERTY(double sessionResetThreshold READ sessionResetThreshold NOTIFY sessionResetThresholdChanged)
@@ -136,6 +137,7 @@ public:
 	bool isSessionPasswordProtected() const { return m_sessionPasswordProtected; }
 	bool isSessionOpword() const { return m_sessionOpword; }
 	bool isSessionNsfm() const { return m_sessionNsfm; }
+	bool isSessionForceNsfm() const { return m_sessionForceNsfm; }
 	bool isSessionDeputies() const { return m_sessionDeputies; }
 	int sessionMaxUserCount() const { return m_sessionMaxUserCount; }
 	double sessionResetThreshold() const { return m_sessionResetThreshold/double(1024*1024); }
@@ -166,6 +168,7 @@ signals:
 	void sessionPasswordChanged(bool passwordProtected);
 	void sessionOpwordChanged(bool opword);
 	void sessionNsfmChanged(bool nsfm);
+	void sessionForceNsfmChanged(bool forceNsfm);
 	void sessionDeputiesChanged(bool deputies);
 	void sessionMaxUserCountChanged(int count);
 	void sessionRoomcodeChanged(const QString &code);
@@ -242,6 +245,7 @@ private:
 	void setSessionResetThreshold(int threshold);
 	void setBaseResetThreshold(int threshold);
 	void setSessionNsfm(bool nsfm);
+	void setSessionForceNsfm(bool forceNsfm);
 	void setSessionDeputies(bool deputies);
 	void setRoomcode(const QString &roomcode);
 
@@ -278,6 +282,7 @@ private:
 	bool m_sessionPasswordProtected;
 	bool m_sessionOpword;
 	bool m_sessionNsfm;
+	bool m_sessionForceNsfm;
 	bool m_sessionDeputies;
 
 	int m_sessionMaxUserCount;

--- a/src/libserver/serverconfig.cpp
+++ b/src/libserver/serverconfig.cpp
@@ -110,6 +110,7 @@ bool ServerConfig::setConfigString(ConfigKey key, const QString &value)
 	// TODO key specific validation
 
 	setConfigValue(key, value);
+	emit configValueChanged(key);
 	return true;
 }
 

--- a/src/libserver/serverconfig.h
+++ b/src/libserver/serverconfig.h
@@ -76,7 +76,8 @@ namespace config {
 		LogPurgeDays(20, "logpurgedays", "0", ConfigKey::INT),               // Automatically purge log entries older than this many days (DB log only)
 		AutoresetThreshold(21, "autoResetThreshold", "15mb", ConfigKey::SIZE), // Default autoreset threshold in bytes
 		AllowCustomAvatars(22, "customAvatars", "true", ConfigKey::BOOL),      // Allow users to set a custom avatar when logging in
-		ExtAuthAvatars(23, "extAuthAvatars", "true", ConfigKey::BOOL)          // Use avatars received from ext-auth server (unless a custom avatar has been set)
+		ExtAuthAvatars(23, "extAuthAvatars", "true", ConfigKey::BOOL),         // Use avatars received from ext-auth server (unless a custom avatar has been set)
+		ForceNsfm(24, "forceNsfm", "false", ConfigKey::BOOL)                   // Force NSFM flag to be set on all sessions
 		;
 }
 
@@ -181,6 +182,9 @@ public:
 	 * @return size in bytes or a negative value in case of error
 	 */
 	static int parseSizeString(const QString &str);
+
+signals:
+	void configValueChanged(const ConfigKey &key);
 
 protected:
 	/**

--- a/src/libserver/session.h
+++ b/src/libserver/session.h
@@ -46,6 +46,7 @@ namespace sessionlisting {
 namespace server {
 
 class Client;
+class ConfigKey;
 class ServerConfig;
 class Log;
 
@@ -354,6 +355,7 @@ signals:
 private slots:
 	void removeUser(Client *user);
 	void onAnnouncementsChanged(const Announcable *session);
+	void onConfigValueChanged(const ConfigKey &key);
 
 protected:
 	Session(SessionHistory *history, ServerConfig *config, sessionlisting::Announcements *announcements, QObject *parent);

--- a/src/thinsrv/multiserver.cpp
+++ b/src/thinsrv/multiserver.cpp
@@ -392,7 +392,8 @@ JsonApiResult MultiServer::serverJsonApi(JsonApiMethod method, const QStringList
 		config::LogPurgeDays,
 		config::AllowCustomAvatars,
 		config::AbuseReport,
-		config::ReportToken
+		config::ReportToken,
+		config::ForceNsfm,
 	};
 	const int settingCount = sizeof(settings) / sizeof(settings[0]);
 


### PR DESCRIPTION
Some servers mandate the use of NSFM on all sessions. This adds a `forceNsfm` config option that enforces this mandate automatically, it makes it so that all sessions are set to NSFM and can't be unset.

This is split into two commits for easier cherry-picking. The server part applies cleanly to master as well, so if a server operator wants to build a server with it, they can do so by running the following:

```bash
# Add my Drawpile repository.
git remote add loom https://github.com/askmeaboutlo0m/Drawpile.git
# Grab the branches from it.
git fetch loom
# Apply the commit to your current state, presumably the official master branch.
git cherry-pick 9e9488a80650984eb784f567c6882b94bd37cd08
```