### PR TITLE
Fix macOS build

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -280,6 +280,7 @@ IF ( APPLE )
 
 	SET(ResourcesDir "${CMAKE_BINARY_DIR}/bin/${CLIENTNAME}.app/Contents/Resources")
 	add_custom_target( appbundle ALL
+		DEPENDS dpclient
 		COMMAND mkdir -p "${ResourcesDir}/i18n"
 		COMMAND cp "${CMAKE_SOURCE_DIR}/desktop/drawpile.icns" "${ResourcesDir}"
 		COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/../libclient/*.qm" "${ResourcesDir}/i18n"


### PR DESCRIPTION
Since the appbundle target copies from files that are generated by the dpclient dependency it must be built first.