### PR TITLE
Add checks in Windows installer for OS prerequisites

### DIFF
--- a/cmake/DrawpilePackaging.cmake
+++ b/cmake/DrawpilePackaging.cmake
@@ -31,6 +31,7 @@ elseif(WIN32)
 
 	include(DrawpileFileExtensions)
 	get_wix_extensions("${PROJECT_NAME}" "drawpile.exe" WIX_DRAWPILE_PROGIDS)
+	math(EXPR WIX_DRAWPILE_TOOLSET_VERSION_MAJOR "${MSVC_TOOLSET_VERSION} / 10")
 	configure_file(pkg/installer.wix.in pkg/installer.wix)
 	set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_BINARY_DIR}/pkg/installer.wix")
 else()

--- a/pkg/installer.wix.in
+++ b/pkg/installer.wix.in
@@ -1,3 +1,21 @@
 <CPackWiXPatch>
 	<CPackWiXFragment Id="CM_CP_drawpile.exe">${WIX_DRAWPILE_PROGIDS}</CPackWiXFragment>
+
+	<CPackWiXFragment Id="#PRODUCT">
+		<Condition Message="${PROJECT_NAME} requires Windows 7 64-bit or later.">
+			<![CDATA[Installed OR (VersionNT64 >= 601)]]>
+		</Condition>
+
+		<Property Id="VC_REDIST_INSTALLED" Secure="yes">
+			<RegistrySearch
+				Id="VC_REDIST_RegKey"
+				Type="raw"
+				Root="HKLM"
+				Key="SOFTWARE\Microsoft\VisualStudio\${WIX_DRAWPILE_TOOLSET_VERSION_MAJOR}.0\VC\Runtimes\X64"
+				Name="Version"/>
+		</Property>
+		<Condition Message="${PROJECT_NAME} requires the Visual Studio x64 Redistributable. Please download and install https://aka.ms/vs/17/release/vc_redist.x64.exe first.">
+			Installed OR VC_REDIST_INSTALLED
+		</Condition>
+	</CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
It is unnecessary to package vc_redist in most cases because it is usually already installed (and Windows Update apparently keeps it up-to-date as of 2019), so including that executable is just wasting disk space and bandwidth for most people.

Trying to download it on-demand in WiX Toolset is possible but burdensome, and would require either using `<CustomAction>` to hack in an on-demand download, or the ‘blessed’ way of creating a second separate bundle installer.

Since this problem is really quite rare, this commit just sets a precondition to make sure that a compatible version of Windows and a compatible version of vc_redist are installed, and prompts the user to manually download and run the installer if not.