### PR TITLE
Ensure svg iconengine is included in packaged AppImage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,11 @@ jobs:
             # This causes the AppImage to be generated, instead of just creating
             # the portable tree, because there seems to be no way to separate
             # these steps with linuxdeploy
-            packager: VERSION=$(git describe) cmake --install build --config Release
+            # Even though the svg component is linked explicitly,
+            # linuxdeploy-plugin-qt does not seem to notice and so does not
+            # export the iconengine if it is not told that we really, really
+            # want svg plugins please
+            packager: EXTRA_QT_PLUGINS="svg;" VERSION=$(git describe) cmake --install build --config Release
 
           # Android common
           - os: ubuntu-latest


### PR DESCRIPTION
Without this, icon lookups fail confusingly by hunting for PNGs and not SVGs within the entire universe of XDG icon directories.

Meta commentary, I don’t feel like the review requirement protected branch rule is a good long-term rule since it reduces velocity, particularly in cases of trivial fixes like this.