### PR TITLE
Continuous Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,12 @@ name: Build and Test
 on:
   pull_request:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      # This tag is (re)created when a build on main succeeds, it'd be
+      # pointless to trigger yet another build in response to it.
+      - continuous
   schedule:
     - cron: '18 11 * * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,28 +281,10 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
-        if: matrix.packager && startsWith(github.ref, 'refs/tags/') != 'true'
+        if: matrix.packager
         with:
           name: Drawpile-${{ matrix.cross_os || runner.os }}-Qt${{ matrix.qt }}
           path: |
-            Drawpile-*.AppImage
-            Drawpile-*.apk
-            Drawpile-*.dmg
-            Drawpile-*.msi
-            Drawpile-*.zip
-
-      - name: Collect release notes
-        run: awk -v RS='' '/^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} Version ${{ github.ref_name }}/,/^[[:digit:]]/' ChangeLog | tail '+2' > ChangeLog-release
-        if: matrix.packager && startsWith(github.ref, 'refs/tags/') == 'true'
-
-      - name: Upload release
-        uses: softprops/action-gh-release@v1
-        if: matrix.packager && startsWith(github.ref, 'refs/tags/') == 'true'
-        with:
-          body_path: ChangeLog-release
-          # In semver, hyphen indicates a pre-release tag
-          prerelease: contains(github.ref, '-')
-          files: |
             Drawpile-*.AppImage
             Drawpile-*.apk
             Drawpile-*.dmg
@@ -331,10 +313,13 @@ jobs:
         if: success() || failure()
         continue-on-error: true
 
-  continuousrelease:
+  release:
     needs: test
     runs-on: ubuntu-latest
-    if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: >
+      success() && (
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+          || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -342,21 +327,37 @@ jobs:
       - name: Dump directory contents
         run: ls -alFR
 
-      - name: Create continuous release
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          path: checkout
+
+      - name: Collect release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        run: awk -v RS='' '/^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} Version ${{ github.ref_name }}/,/^[[:digit:]]/' checkout/ChangeLog | tail '+2' > release-description
+
+      - name: Write continuous release description
+        if: "!startsWith(github.ref, 'refs/tags/')"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_COMMIT: ${{ github.sha }}
-          RELEASE_NAME: continuous
           RELEASE_DESCRIPTION: >
             This release is an automatically generated snapshot of the current
             state of development. It is continuously updated with
             work-in-progress changes that may be broken, incomplete, or
             incompatible with other versions of Drawpile. For downloads, take a
             look at the Assets below.
+        run:
+          echo "$RELEASE_DESCRIPTION" > release-description
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_COMMIT: ${{ github.sha }}
+          RELEASE_DESCRIPTION_FILE: release-description
+          RELEASE_NAME: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'continuous' }}
+          CLOBBER_EXISTING: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          PRERELEASE: ${{ !startsWith(github.ref, 'refs/tags/') || contains(github.ref, '-') }}
         run: |
-          wget -q https://raw.githubusercontent.com/drawpile/Drawpile/main/pkg/make-github-release.sh
-          chmod +x make-github-release.sh
-          ./make-github-release.sh \
+          checkout/pkg/make-github-release.sh \
             'Drawpile-Android-Qt5.15.8;Drawpile-*.apk;Android APK' \
             'Drawpile-Linux-Qt5.15.8;Drawpile-*.AppImage;Linux AppImage' \
             'Drawpile-macOS-Qt5.15.8;Drawpile-*.dmg;macOS Disk Image' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
       # This tag is (re)created when a build on main succeeds, it'd be
       # pointless to trigger yet another build in response to it.
       - continuous
+      - continuoustest
   schedule:
     - cron: '18 11 * * *'
 
@@ -330,3 +331,33 @@ jobs:
         run: sccache --show-stats
         if: success() || failure()
         continue-on-error: true
+
+  continuousrelease:
+    needs: test
+    runs-on: ubuntu-latest
+    if: success() && github.ref == format('refs/heads/{0}', 'feature/continuous-release')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Dump directory contents
+        run: ls -alFR
+
+      - name: Create continuous release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          TARGET_COMMIT: ${{ github.sha }}
+          RELEASE_NAME: continuoustest
+          RELEASE_DESCRIPTION: >
+            Automatic, continuous development release. This is for testing
+            purposes and may be unstable! For downloads, look at the Assets
+            below. This is a test of the release script itself.
+        run: |
+          wget -q https://raw.githubusercontent.com/drawpile/Drawpile/feature/continuous-release/pkg/make-github-release.sh
+          chmod +x make-github-release.sh
+          ./make-github-release.sh \
+            'Drawpile-Android-Qt5.15.8.zip;Drawpile-*.apk;Android APK' \
+            'Drawpile-Linux-Qt5.15.8.zip;Drawpile-*.AppImage;Linux AppImage' \
+            'Drawpile-macOS-Qt5.15.8.zip;Drawpile-*.dmg;macOS Disk Image' \
+            'Drawpile-Windows-Qt5.15.8.zip;Drawpile-*.msi;Windows Installer' \
+            'Drawpile-Windows-Qt5.15.8.zip;Drawpile-*.zip;Windows Portable ZIP'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
       # This tag is (re)created when a build on main succeeds, it'd be
       # pointless to trigger yet another build in response to it.
       - continuous
-      - continuoustest
   schedule:
     - cron: '18 11 * * *'
 
@@ -335,29 +334,31 @@ jobs:
   continuousrelease:
     needs: test
     runs-on: ubuntu-latest
-    if: success() && github.ref == format('refs/heads/{0}', 'feature/continuous-release')
+    if: success() && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Dump directory contents
         run: ls -alFR
 
       - name: Create continuous release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_COMMIT: ${{ github.sha }}
-          RELEASE_NAME: continuoustest
+          RELEASE_NAME: continuous
           RELEASE_DESCRIPTION: >
-            Automatic, continuous development release. This is for testing
-            purposes and may be unstable! For downloads, look at the Assets
-            below. This is a test of the release script itself.
+            This release is an automatically generated snapshot of the current
+            state of development. It is continuously updated with
+            work-in-progress changes that may be broken, incomplete, or
+            incompatible with other versions of Drawpile. For downloads, take a
+            look at the Assets below.
         run: |
-          wget -q https://raw.githubusercontent.com/drawpile/Drawpile/feature/continuous-release/pkg/make-github-release.sh
+          wget -q https://raw.githubusercontent.com/drawpile/Drawpile/main/pkg/make-github-release.sh
           chmod +x make-github-release.sh
           ./make-github-release.sh \
-            'Drawpile-Android-Qt5.15.8.zip;Drawpile-*.apk;Android APK' \
-            'Drawpile-Linux-Qt5.15.8.zip;Drawpile-*.AppImage;Linux AppImage' \
-            'Drawpile-macOS-Qt5.15.8.zip;Drawpile-*.dmg;macOS Disk Image' \
-            'Drawpile-Windows-Qt5.15.8.zip;Drawpile-*.msi;Windows Installer' \
-            'Drawpile-Windows-Qt5.15.8.zip;Drawpile-*.zip;Windows Portable ZIP'
+            'Drawpile-Android-Qt5.15.8;Drawpile-*.apk;Android APK' \
+            'Drawpile-Linux-Qt5.15.8;Drawpile-*.AppImage;Linux AppImage' \
+            'Drawpile-macOS-Qt5.15.8;Drawpile-*.dmg;macOS Disk Image' \
+            'Drawpile-Windows-Qt5.15.8;Drawpile-*.msi;Windows Installer' \
+            'Drawpile-Windows-Qt5.15.8;Drawpile-*.zip;Windows Portable ZIP'

--- a/pkg/make-github-release.sh
+++ b/pkg/make-github-release.sh
@@ -7,11 +7,6 @@ note() {
     echo "$@" 1>&2
 }
 
-die() {
-    note "$@"
-    exit 1
-}
-
 check_args() {
     local error fields var
     error=0
@@ -55,133 +50,38 @@ check_args() {
 
 check_args "$@"
 
-BASE_URL="${BASE_URL:-https://api.github.com}"
 GIT_REPO_SLUG="${GIT_REPO_SLUG:-drawpile/Drawpile}"
 
-prepare_assets() {
-    local dir pattern path count
-    while [[ $# -ne 0 ]]; do
-        IFS=';' read -ra fields <<< "$1"
-        shift
+assets=()
+error=0
+while [[ $# -ne 0 ]]; do
+    IFS=';' read -ra fields <<< "$1"
+    shift
 
-        dir="${fields[0]}"
-        pattern="${fields[1]}"
-        path="$(find "$dir" -name "$pattern")"
-        count="$(echo "$path" | wc -l)"
-        if [[ $count -ne 1 ]]; then
-            die "$dir: expected 1 path matching '$pattern', but got $count"
-        fi
+    dir="${fields[0]}"
+    pattern="${fields[1]}"
+    path="$(find "$dir" -name "$pattern")"
+    count="$(echo "$path" | wc -l)"
+    if [[ $count -ne 1 ]]; then
+        note "$dir: expected 1 path matching '$pattern', but got $count"
+        error=1
+    fi
 
-        # Write out path and label pairs, later processed by upload_assets.
-        echo "$path"
-        echo "${fields[2]}"
-    done
-}
+    assets+=("$path#${fields[2]}")
+done
 
-api_call() {
-    local method url
-    method="$1"
-    url="$2"
-    shift 2
-    curl --no-progress-meter -L -X "$method" \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: token $GITHUB_TOKEN"\
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        "$@" "$url" | jq -MS
-}
-
-get_existing_release() {
-    note "Get release '$RELEASE_NAME'"
-    api_call GET "$BASE_URL/repos/$GIT_REPO_SLUG/releases/tags/$RELEASE_NAME"
-}
-
-delete_existing_release() {
-    local release_id
-    release_id="$1"
-    note "Delete release with id '$release_id'"
-    api_call DELETE "$BASE_URL/repos/$GIT_REPO_SLUG/releases/$release_id"
-}
-
-delete_existing_tag() {
-    note "Delete tag '$RELEASE_NAME'"
-    api_call DELETE "$BASE_URL/repos/$GIT_REPO_SLUG/git/refs/tags/$RELEASE_NAME"
-}
-
-create_release() {
-    local json
-    note "Create release '$RELEASE_NAME' on commit '$TARGET_COMMIT'"
-    json="$(jq -n \
-        --arg name "$RELEASE_NAME" \
-        --arg commit "$TARGET_COMMIT" \
-        --arg body "$RELEASE_DESCRIPTION" \
-        '{
-            "body": $body,
-            "draft": true,
-            "name": $name,
-            "prerelease": true,
-            "tag_name": $name,
-            "target_commitish": $commit
-        }')"
-    api_call POST "$BASE_URL/repos/$GIT_REPO_SLUG/releases" -d "$json"
-}
-
-urlencode() {
-    printf '%s' "$1" | jq -sRr '@uri'
-}
-
-create_release_asset() {
-    local url path label name
-    url="$1"
-    path="$2"
-    label="$3"
-    name="$(basename "$path")"
-    note "Create release asset named '$name' labeled '$label' from '$path'"
-    api_call POST "$url?name=$(urlencode "$name")&label=$(urlencode "$label")" \
-        -H "Content-Type: application/octet-stream" \
-        --data-binary "@$path"
-}
-
-upload_assets() {
-    local url
-    url="$1"
-    # Read two lines at a time, first line is the path, second is the label.
-    while mapfile -t -n 2 pair && [[ ${#pair[@]} -ne 0 ]]; do
-        create_release_asset "$url" "${pair[0]}" "${pair[1]}"
-    done
-}
-
-publish_release() {
-    local release_id
-    release_id="$1"
-    note "Publish release with id '$release_id'"
-    api_call PATCH "$BASE_URL/repos/$GIT_REPO_SLUG/releases/$release_id" \
-        -d '{"draft":false}'
-}
-
-# Check if all assets are present. The result will be pairs of lines, the first
-# line in each pair is the path, the second is the label.
-assets_to_upload="$(prepare_assets "$@")"
-
-# If we already have a release of the same name, we replace it.
-existing_release="$(get_existing_release)"
-if echo "$existing_release" | jq -e .id >/dev/null; then
-    existing_release_id="$(echo "$existing_release" | jq -r .id)"
-    delete_existing_release "$existing_release_id"
+if [[ $error -ne 0 ]]; then
+    note 'Error(s) collecting release assets'
+    exit 1
 fi
 
-# Don't bother to check if the tags exists, just try to delete it.
-delete_existing_tag
+gh release delete --repo "$GIT_REPO_SLUG" --cleanup-tag --yes "$RELEASE_NAME" \
+    || true
 
-# Create the release in draft mode.
-release="$(create_release)"
-if echo "$release" | jq -e .upload_url >/dev/null; then
-    # The release contains a URL to use for uploading assets to, but it has some
-    # some hypermedia "garbage" in braces at the end that we need to strip off.
-    upload_url="$(echo "$release" | jq -r .upload_url | perl -pe 's/\{.*\}$//')"
-    echo "$assets_to_upload" | upload_assets "$upload_url"
-    # Switch the release over from draft to published.
-    release_id="$(echo "$release" | jq -r .id)"
-    publish_release "$release_id"
-else
-    die 'No upload_url in release response, release creation probably failed'
-fi
+gh release create \
+    --repo "$GIT_REPO_SLUG" \
+    --prerelease \
+    --target "$TARGET_COMMIT" \
+    --title "$RELEASE_NAME" \
+    --notes "$RELEASE_DESCRIPTION" \
+    "$RELEASE_NAME" "${assets[@]}"

--- a/pkg/make-github-release.sh
+++ b/pkg/make-github-release.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+set -ueo pipefail
+set +x
+
+note() {
+    echo "$@" 1>&2
+}
+
+die() {
+    note "$@"
+    exit 1
+}
+
+check_args() {
+    local error fields var
+    error=0
+
+    if [[ $# -eq 0 ]]; then
+        note 'No assets to upload given'
+        error=1
+    else
+        while [[ $# -ne 0 ]]; do
+            IFS=';' read -ra fields <<< "$1"
+            if [[ ${#fields[@]} -ne 3 ]]; then
+                note "Invalid argument '$1'"
+                error=1
+            fi
+            shift
+        done
+    fi
+
+    if [[ $error -ne 0 ]]; then
+        note
+        note 'Each argument must be a triple of the form: dir;pattern;label'
+        note 'dir: The directory that the asset is found in.'
+        note 'pattern: A "find" pattern to get the file in "dir".'
+        note 'label: What to call this asset when uploaded to the release.'
+        note
+    fi
+
+    for var in GITHUB_TOKEN TARGET_COMMIT RELEASE_NAME RELEASE_DESCRIPTION; do
+        if [[ -z "${!var:-}" ]]; then
+            note "Environment variable '$var' must be set"
+            error=1
+        fi
+    done
+
+    if [[ $error -ne 0 ]]; then
+        note
+        note 'Invalid arguments and/or environment variables given, exiting'
+        exit 2
+    fi
+}
+
+check_args "$@"
+
+BASE_URL="${BASE_URL:-https://api.github.com}"
+GIT_REPO_SLUG="${GIT_REPO_SLUG:-drawpile/Drawpile}"
+
+prepare_assets() {
+    local dir pattern path count
+    while [[ $# -ne 0 ]]; do
+        IFS=';' read -ra fields <<< "$1"
+        shift
+
+        dir="${fields[0]}"
+        pattern="${fields[1]}"
+        path="$(find "$dir" -name "$pattern")"
+        count="$(echo "$path" | wc -l)"
+        if [[ $count -ne 1 ]]; then
+            die "$dir: expected 1 path matching '$pattern', but got $count"
+        fi
+
+        # Write out path and label pairs, later processed by upload_assets.
+        echo "$path"
+        echo "${fields[2]}"
+    done
+}
+
+api_call() {
+    local method url
+    method="$1"
+    url="$2"
+    shift 2
+    curl --no-progress-meter -L -X "$method" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: token $GITHUB_TOKEN"\
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$@" "$url" | jq -MS
+}
+
+get_existing_release() {
+    note "Get release '$RELEASE_NAME'"
+    api_call GET "$BASE_URL/repos/$GIT_REPO_SLUG/releases/tags/$RELEASE_NAME"
+}
+
+delete_existing_release() {
+    local release_id
+    release_id="$1"
+    note "Delete release with id '$release_id'"
+    api_call DELETE "$BASE_URL/repos/$GIT_REPO_SLUG/releases/$release_id"
+}
+
+delete_existing_tag() {
+    note "Delete tag '$RELEASE_NAME'"
+    api_call DELETE "$BASE_URL/repos/$GIT_REPO_SLUG/git/refs/tags/$RELEASE_NAME"
+}
+
+create_release() {
+    local json
+    note "Create release '$RELEASE_NAME' on commit '$TARGET_COMMIT'"
+    json="$(jq -n \
+        --arg name "$RELEASE_NAME" \
+        --arg commit "$TARGET_COMMIT" \
+        --arg body "$RELEASE_DESCRIPTION" \
+        '{
+            "body": $body,
+            "draft": true,
+            "name": $name,
+            "prerelease": true,
+            "tag_name": $name,
+            "target_commitish": $commit
+        }')"
+    api_call POST "$BASE_URL/repos/$GIT_REPO_SLUG/releases" -d "$json"
+}
+
+urlencode() {
+    printf '%s' "$1" | jq -sRr '@uri'
+}
+
+create_release_asset() {
+    local url path label name
+    url="$1"
+    path="$2"
+    label="$3"
+    name="$(basename "$path")"
+    note "Create release asset named '$name' labeled '$label' from '$path'"
+    api_call POST "$url?name=$(urlencode "$name")&label=$(urlencode "$label")" \
+        -H "Content-Type: application/octet-stream" \
+        --data-binary "@$path"
+}
+
+upload_assets() {
+    local url
+    url="$1"
+    # Read two lines at a time, first line is the path, second is the label.
+    while mapfile -t -n 2 pair && [[ ${#pair[@]} -ne 0 ]]; do
+        create_release_asset "$url" "${pair[0]}" "${pair[1]}"
+    done
+}
+
+publish_release() {
+    local release_id
+    release_id="$1"
+    note "Publish release with id '$release_id'"
+    api_call PATCH "$BASE_URL/repos/$GIT_REPO_SLUG/releases/$release_id" \
+        -d '{"draft":false}'
+}
+
+# Check if all assets are present. The result will be pairs of lines, the first
+# line in each pair is the path, the second is the label.
+assets_to_upload="$(prepare_assets "$@")"
+
+# If we already have a release of the same name, we replace it.
+existing_release="$(get_existing_release)"
+if echo "$existing_release" | jq -e .id >/dev/null; then
+    existing_release_id="$(echo "$existing_release" | jq -r .id)"
+    delete_existing_release "$existing_release_id"
+fi
+
+# Don't bother to check if the tags exists, just try to delete it.
+delete_existing_tag
+
+# Create the release in draft mode.
+release="$(create_release)"
+if echo "$release" | jq -e .upload_url >/dev/null; then
+    # The release contains a URL to use for uploading assets to, but it has some
+    # some hypermedia "garbage" in braces at the end that we need to strip off.
+    upload_url="$(echo "$release" | jq -r .upload_url | perl -pe 's/\{.*\}$//')"
+    echo "$assets_to_upload" | upload_assets "$upload_url"
+    # Switch the release over from draft to published.
+    release_id="$(echo "$release" | jq -r .id)"
+    publish_release "$release_id"
+else
+    die 'No upload_url in release response, release creation probably failed'
+fi

--- a/pkg/release.sh
+++ b/pkg/release.sh
@@ -7,7 +7,7 @@ DEFAULT_REPO=drawpile/Drawpile
 usage() {
 	echo "Usage: $0 [branch] [version]"
 	echo
-	echo "Branch defaults to 'master'."
+	echo "Branch defaults to 'main'."
 	echo "Version defaults to what is listed in Cargo.toml in the branch."
 	echo "Version should only be specified for pre-releases."
 	echo
@@ -24,7 +24,7 @@ set_package_version() {
 if [ "$1" == "--help" ]; then
 	usage
 elif [ "$1" == "" ]; then
-	BRANCH="master"
+	BRANCH="main"
 else
 	BRANCH=$1
 fi


### PR DESCRIPTION
Generates a release named `continuous` under a tag with the same name for every successful build on main.

Example run: <https://github.com/drawpile/Drawpile/actions/runs/4734393156>

Example release: <https://github.com/drawpile/Drawpile/releases/tag/continuoustest>

Will probably wait for #1070 to get merged so that the release it generates will actually work on Windows.