### PR TITLE
Improve build times with precompiled headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,6 +234,7 @@ jobs:
           -DTESTS=on
           "-DCMAKE_PREFIX_PATH=${{ matrix.cross_os && format('{0};', steps.cross-deps.outputs.path) }}${{ steps.deps.outputs.path }}"
           -DCMAKE_INSTALL_PREFIX=out
+          -DCMAKE_DISABLE_PRECOMPILE_HEADERS=on
           -DCLANG_TIDY=${{ github.event_name != 'push' && 'on' || 'off' }}
           -DDIST_BUILD=${{ matrix.packager && 'on' }}
           -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${{

--- a/cmake/DrawpileCompilerOptions.cmake
+++ b/cmake/DrawpileCompilerOptions.cmake
@@ -19,9 +19,12 @@ if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
 endif()
 add_feature_info("Interprocedural optimization (CMAKE_INTERPROCEDURAL_OPTIMIZATION)" CMAKE_INTERPROCEDURAL_OPTIMIZATION "")
 
+if(WIN32)
+	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
 if(MSVC)
 	add_compile_options(/utf-8 /W4)
-	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 
 	if($ENV{CI})
 		add_compile_options(/WX)
@@ -103,6 +106,12 @@ else()
 
 	get_directory_property(IGNORE_WARNINGS_COMPILE_OPTIONS COMPILE_OPTIONS)
 	list(TRANSFORM IGNORE_WARNINGS_COMPILE_OPTIONS REPLACE "-W(no-)?([^=]+)(=.*$)?" "-Wno-\\2")
+
+	# Will cause “__DEPRECATED predefined macro was enabled in PCH file but is
+	# currently disabled” error if disabled with precompiled headers
+	if (CXX_HAS_DEPRECATED AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+		list(TRANSFORM IGNORE_WARNINGS_COMPILE_OPTIONS REPLACE "-Wno-deprecated" "")
+	endif()
 endif()
 
 foreach(lang IN LISTS ENABLED_LANGUAGES)

--- a/cmake/DrawpileOptions.cmake
+++ b/cmake/DrawpileOptions.cmake
@@ -67,3 +67,5 @@ unset(san_upper)
 # UNITY_BUILD is already used by cmake
 option(DP_UNITY_BUILD "Unity builds for Drawpile (not Drawdance)" OFF)
 add_feature_info("Unity builds for Drawpile (DP_UNITY_BUILD)" DP_UNITY_BUILD "")
+
+add_feature_info("Precompiled headers (CMAKE_DISABLE_PRECOMPILE_HEADERS)" "NOT CMAKE_DISABLE_PRECOMPILE_HEADERS" "")

--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -288,6 +288,34 @@ target_link_libraries(drawpile PRIVATE
 	${QT_PACKAGE_NAME}::Multimedia
 )
 
+if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS) 
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pch.h" "
+		#include <QtCore>
+		#include <QtGui>
+		#include <QtWidgets>
+
+		#include <libclient/brushes/brush.h>
+		#include <libclient/canvas/acl.h>
+		#include <libclient/canvas/canvasmodel.h>
+		#include <libclient/canvas/layerlist.h>
+		#include <libclient/canvas/paintengine.h>
+		#include <libclient/canvas/userlist.h>
+		#include <libclient/tools/toolcontroller.h>
+		#include <libclient/utils/kis_cubic_curve.h>
+		#include <libshared/util/qtcompat.h>
+
+		// defined by windows.h and conflicts with variable names
+		#ifdef far
+		#	undef far
+		#endif
+		#ifdef near
+		#	undef near
+		#endif	
+	")
+	target_precompile_headers(drawpile PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/pch.h") 
+endif()
+
+
 if(VERSION_CHECK)
 	target_sources(drawpile PRIVATE
 		dialogs/versioncheckdialog.cpp
@@ -462,6 +490,22 @@ else()
 	target_disable_all_warnings(drawpile-QtColorWidgets)
 	set_target_properties(drawpile-QtColorWidgets
 		PROPERTIES DP_AUTO_SOURCE_TREE_BASE bundled/QtColorWidgets
+	)	
+
+	target_precompile_headers(drawpile-QtColorWidgets PRIVATE 
+		<QtCore>
+		<QtGui>
+		<QtWidgets>
+		[["QtColorWidgets/abstract_widget_list.hpp"]]
+		[["QtColorWidgets/color_delegate.hpp"]]
+		[["QtColorWidgets/color_line_edit.hpp"]]
+		[["QtColorWidgets/color_list_widget.hpp"]]
+		[["QtColorWidgets/color_palette_widget.hpp"]]
+		[["QtColorWidgets/color_preview.hpp"]]
+		[["QtColorWidgets/color_selector.hpp"]]
+		[["QtColorWidgets/color_wheel.hpp"]]
+		[["QtColorWidgets/color_wheel_private.hpp"]]
+		[["QtColorWidgets/gradient_slider.hpp"]]
 	)
 
 	target_link_libraries(drawpile PRIVATE drawpile-QtColorWidgets)

--- a/src/desktop/bundled/QtColorWidgets/include/QtColorWidgets/color_wheel_private.hpp
+++ b/src/desktop/bundled/QtColorWidgets/include/QtColorWidgets/color_wheel_private.hpp
@@ -20,6 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifndef COLOR_WHEEL_PRIVATE_HPP
+#define COLOR_WHEEL_PRIVATE_HPP
 
 #include "QtColorWidgets/color_wheel.hpp"
 #include "QtColorWidgets/color_utils.hpp"
@@ -292,3 +294,5 @@ public:
 };
 
 } //  namespace color_widgets
+
+#endif

--- a/src/desktop/bundled/kis_tablet/kis_tablet_support_win.cpp
+++ b/src/desktop/bundled/kis_tablet/kis_tablet_support_win.cpp
@@ -433,14 +433,14 @@ bool KisWindowsWinTab32DLL::init()
         return true;
     }
     qWarning() << "Could not resolve the following symbols:\n"
-               << "\t wTOpen" << wTOpen << "\n"
-               << "\t wtClose" << wTClose << "\n"
-               << "\t wtInfo" << wTInfo << "\n"
-               << "\t wTEnable" << wTEnable << "\n"
-               << "\t wTOverlap" << wTOverlap << "\n"
-               << "\t wTPacketsGet" << wTPacketsGet << "\n"
-               << "\t wTQueueSizeGet" << wTQueueSizeGet << "\n"
-               << "\t wTQueueSizeSet" << wTQueueSizeSet << "\n";
+               << "\t wTOpen" << (intptr_t)wTOpen << "\n"
+               << "\t wtClose" << (intptr_t)wTClose << "\n"
+               << "\t wtInfo" << (intptr_t)wTInfo << "\n"
+               << "\t wTEnable" << (intptr_t)wTEnable << "\n"
+               << "\t wTOverlap" << (intptr_t)wTOverlap << "\n"
+               << "\t wTPacketsGet" << (intptr_t)wTPacketsGet << "\n"
+               << "\t wTQueueSizeGet" << (intptr_t)wTQueueSizeGet << "\n"
+               << "\t wTQueueSizeSet" << (intptr_t)wTQueueSizeSet << "\n";
     return false;
 }
 

--- a/src/libclient/CMakeLists.txt
+++ b/src/libclient/CMakeLists.txt
@@ -203,6 +203,31 @@ target_link_libraries(dpclient
 		Drawdance::dpmsg
 )
 
+if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS) 
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pch.h" "
+		#include <QtCore>
+		#include <QtGui>
+		#include <QtNetwork>
+		#include <QtSql>
+
+		extern \"C\" {
+		#include <dpcommon/geom.h>
+		#include <dpengine/canvas_history.h>
+		#include <dpengine/paint_engine.h>
+		}
+
+		// defined by windows.h and conflicts with variable names
+		#ifdef far
+		#	undef far
+		#endif
+		#ifdef near
+		#	undef near
+		#endif
+	")
+	target_precompile_headers(dpclient PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/pch.h") 
+endif()
+
+
 if(${QT_PACKAGE_NAME}LinguistTools_FOUND)
 	add_subdirectory(i18n)
 endif()

--- a/src/libclient/parentalcontrols/parentalcontrols_win.cpp
+++ b/src/libclient/parentalcontrols/parentalcontrols_win.cpp
@@ -2,6 +2,10 @@
 
 #include "libclient/parentalcontrols/parentalcontrols.h"
 
+// Qt headers include win32 headers but undef "interface", causing issues when including <wpcapi.h>
+#ifndef interface
+	#define interface __STRUCT__
+#endif
 #include <wpcapi.h>
 
 #include <QDebug>

--- a/src/libserver/CMakeLists.txt
+++ b/src/libserver/CMakeLists.txt
@@ -51,6 +51,13 @@ target_link_libraries(dpserver
 		${QT_PACKAGE_NAME}::Network
 )
 
+target_precompile_headers(dpserver PRIVATE 
+	<QtCore>
+	<QtNetwork>
+	<libshared/net/message.h>
+	<libshared/net/protover.h>
+)
+
 if(TESTS)
 	add_subdirectory(tests)
 endif()

--- a/src/libshared/CMakeLists.txt
+++ b/src/libshared/CMakeLists.txt
@@ -66,6 +66,12 @@ target_link_libraries(dpshared
 		${QT_PACKAGE_NAME}::Network
 )
 
+target_precompile_headers(dpshared PRIVATE
+	<QtCore>
+	<QtNetwork>
+)
+
+
 if(ANDROID)
 	target_sources(dpshared PRIVATE
 		util/androidutils.cpp

--- a/src/thinsrv/CMakeLists.txt
+++ b/src/thinsrv/CMakeLists.txt
@@ -201,6 +201,14 @@ if(INSTALL_DOC AND UNIX)
 	)
 endif()
 
+target_precompile_headers(${srvlib} PRIVATE 
+	<QtCore> 
+	<QtNetwork> 
+	<QtSql> 
+	<libserver/jsonapi.h> 
+	<libserver/serverconfig.h>
+)
+
 if(TESTS)
 	add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Using MSVC, Debug build time went from `40s` -> `28s`. Release (with LTO) went from `46s` -> `30s`.
Could possibly be improved further by using precompiled headers for drawdance (for common headers like `common.h` and `atomic.h`).

They are disabled in CI because clang-tidy doesn't like them. And weird stuff happens with warnings on MSVC.