### PR TITLE
Keep brush preview ambience static

### DIFF
--- a/extern/drawdance/libengine/dpengine/brush_preview.c
+++ b/extern/drawdance/libengine/dpengine/brush_preview.c
@@ -42,10 +42,6 @@
 #include <helpers.h> // CLAMP, M_PI
 
 
-#define FOREGROUND_SOLID 0
-#define FOREGROUND_BARS  1
-#define FOREGROUND_DABS  2
-
 #define PI_FLOAT   ((float)M_PI)
 #define DELTA_MSEC 20
 
@@ -133,13 +129,6 @@ static uint32_t hsv_to_bgra(float h, float s, float v)
     hsv_to_rgb_float(&h, &s, &v);
     DP_UPixelFloat pixel = {v, s, h, 1.0f};
     return DP_pixel8_premultiply(DP_upixel_float_to_8(pixel)).color;
-}
-
-static void set_background_color(DP_UNUSED size_t size, unsigned char *out,
-                                 void *user)
-{
-    DP_ASSERT(size == 4);
-    DP_write_bigendian_uint32(*(uint32_t *)user, out);
 }
 
 static void set_preview_foreground_dab(DP_UNUSED int count, DP_PixelDab *pds,
@@ -257,8 +246,7 @@ static void stroke_flood_fill_blob(DP_BrushEngine *be, DP_CanvasState *cs,
 
 void render_brush_preview(
     DP_BrushPreview *bp, DP_DrawContext *dc, int width, int height,
-    DP_BrushPreviewShape shape, DP_UPixelFloat initial_color, bool smudge,
-    DP_BlendMode mode,
+    DP_BrushPreviewShape shape, DP_UPixelFloat initial_color,
     void (*set_brush)(void *, DP_BrushEngine *, DP_UPixelFloat), void *user)
 {
     DP_ASSERT(bp);
@@ -271,51 +259,23 @@ void render_brush_preview(
 
     uint32_t color =
         DP_pixel8_premultiply(DP_upixel_float_to_8(initial_color)).color;
-    uint32_t background_color =
-        is_dark_color(initial_color) ? 0xfffafafau : 0xff202020u;
-
-    uint32_t layer_color = 0;
-    int foreground_style = smudge ? FOREGROUND_BARS : FOREGROUND_SOLID;
-
-    if (mode == DP_BLEND_MODE_ERASE) {
-        layer_color = 0xff202020u;
-        background_color = 0;
-    }
-    else if (mode == DP_BLEND_MODE_COLOR_ERASE) {
-        layer_color = color;
-        background_color = 0;
-    }
-    else if (mode == DP_BLEND_MODE_NORMAL_AND_ERASER) {
-        layer_color = background_color;
-        background_color = 0;
-    }
-    else if (!DP_blend_mode_can_increase_opacity((int)mode)) {
-        foreground_style = FOREGROUND_DABS;
-        background_color = 0;
-    }
+    uint32_t layer_color = shape == DP_BRUSH_PREVIEW_FLOOD_ERASE ? color : 0;
 
     DP_UPixelFloat brush_color;
-    switch (shape) {
-    case DP_BRUSH_PREVIEW_FLOOD_FILL:
-        brush_color = (DP_UPixelFloat){0.0f, 0.0f, 0.0f, 0.0f};
-        background_color = 0;
-        break;
-    case DP_BRUSH_PREVIEW_FLOOD_ERASE:
-        layer_color = color;
-        brush_color = DP_upixel8_to_float(
-            DP_pixel8_unpremultiply((DP_Pixel8){background_color}));
-        background_color = 0;
-        break;
-    default:
+    bool foreground_dabs;
+    bool is_flood = shape == DP_BRUSH_PREVIEW_FLOOD_FILL
+                 || shape == DP_BRUSH_PREVIEW_FLOOD_ERASE;
+    if (is_flood) {
+        brush_color = DP_upixel8_to_float(DP_pixel8_unpremultiply((DP_Pixel8){
+            is_dark_color(initial_color) ? 0xfffafafau : 0xff202020u}));
+        foreground_dabs = false;
+    }
+    else {
         brush_color = initial_color;
-        break;
+        foreground_dabs = true;
     }
 
     DP_CanvasState *cs = DP_canvas_state_new();
-    cs = handle_preview_message_dec(
-        cs, dc,
-        DP_msg_canvas_background_new(0, set_background_color, 4,
-                                     &background_color));
     cs = handle_preview_message_dec(
         cs, dc,
         DP_msg_canvas_resize_new(0, 0, DP_int_to_int32(width),
@@ -324,28 +284,7 @@ void render_brush_preview(
         cs, dc,
         DP_msg_layer_tree_create_new(0, 1, 0, 0, layer_color, 0, "", 0));
 
-    switch (foreground_style) {
-    case FOREGROUND_SOLID:
-        if (mode == DP_BLEND_MODE_BEHIND) {
-            // Put something on the layer to draw behind.
-            uint32_t w = DP_int_to_uint32(width);
-            uint32_t h = DP_int_to_uint32(height);
-            uint32_t b = DP_int_to_uint32(DP_max_int(width / 20, 2));
-            cs = handle_preview_message_dec(
-                cs, dc,
-                DP_msg_fill_rect_new(0, 1, DP_BLEND_MODE_NORMAL,
-                                     w / 4u - b / 2u, 0, b, h, 0xff000000));
-            cs = handle_preview_message_dec(
-                cs, dc,
-                DP_msg_fill_rect_new(0, 1, DP_BLEND_MODE_NORMAL,
-                                     w / 4u * 2 - b / 2u, 0, b, h, 0xff000000));
-            cs = handle_preview_message_dec(
-                cs, dc,
-                DP_msg_fill_rect_new(0, 1, DP_BLEND_MODE_NORMAL,
-                                     w / 4u * 3 - b / 2u, 0, b, h, 0xff000000));
-        }
-        break;
-    case FOREGROUND_DABS: {
+    if (foreground_dabs) {
         int d = CLAMP(height * 2 / 3, 10, 255);
         int x0 = d;
         int x1 = width - d;
@@ -362,28 +301,6 @@ void render_brush_preview(
                     hsv_to_bgra(hue, 0.62f, 0.86f) & 0x00ffffffu,
                     DP_BLEND_MODE_NORMAL, set_preview_foreground_dab, 1, &d));
         }
-        break;
-    }
-    case FOREGROUND_BARS: {
-        uint32_t h = DP_int_to_uint32(height);
-        uint32_t bars = 5;
-        float barsf = DP_uint32_to_float(bars);
-        float bw = DP_int_to_float(width) / barsf;
-        float x = 0.0f;
-        for (uint32_t i = 0; i < bars; ++i) {
-            float hue = DP_uint32_to_float(i) / barsf;
-            cs = handle_preview_message_dec(
-                cs, dc,
-                DP_msg_fill_rect_new(0, 1, DP_BLEND_MODE_NORMAL,
-                                     DP_float_to_uint32(x), 0,
-                                     DP_float_to_uint32(bw) + i, h,
-                                     hsv_to_bgra(hue, 0.62f, 0.86f)));
-            x += bw;
-        }
-        break;
-    }
-    default:
-        DP_UNREACHABLE();
     }
 
     DP_Rect rect = DP_rect_make(width / 8, height / 4, width - width / 4,
@@ -439,8 +356,6 @@ void DP_brush_preview_render_classic(DP_BrushPreview *bp, DP_DrawContext *dc,
     DP_ASSERT(dc);
     DP_ASSERT(brush);
     render_brush_preview(bp, dc, width, height, shape, brush->color,
-                         brush->smudge.max > 0.0f,
-                         DP_classic_brush_blend_mode(brush),
                          set_preview_classic_brush, (void *)brush);
 }
 
@@ -453,23 +368,6 @@ static void set_preview_mypaint_brush(void *user, DP_BrushEngine *be,
     DP_brush_engine_mypaint_brush_set(be, brush, settings, &stroke, &color);
 }
 
-static bool has_smudge_setting(const DP_MyPaintSettings *settings)
-{
-    const DP_MyPaintMapping *mapping =
-        &settings->mappings[MYPAINT_BRUSH_SETTING_SMUDGE];
-    if (mapping->base_value == 0) {
-        for (int i = 0; i < MYPAINT_BRUSH_INPUTS_COUNT; ++i) {
-            if (mapping->inputs[i].n != 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-    else {
-        return true;
-    }
-}
-
 void DP_brush_preview_render_mypaint(DP_BrushPreview *bp, DP_DrawContext *dc,
                                      int width, int height,
                                      const DP_MyPaintBrush *brush,
@@ -480,11 +378,7 @@ void DP_brush_preview_render_mypaint(DP_BrushPreview *bp, DP_DrawContext *dc,
     DP_ASSERT(dc);
     DP_ASSERT(brush);
     DP_ASSERT(settings);
-    DP_BlendMode mode = brush->erase      ? DP_BLEND_MODE_ERASE
-                      : brush->lock_alpha ? DP_BLEND_MODE_RECOLOR
-                                          : DP_BLEND_MODE_NORMAL_AND_ERASER;
     render_brush_preview(bp, dc, width, height, shape, brush->color,
-                         has_smudge_setting(settings), mode,
                          set_preview_mypaint_brush,
                          (void *[]){(void *)brush, (void *)settings});
 }


### PR DESCRIPTION
Using the colored dabs over a transparent background in all cases and just drawing the brush strokes over that. The flood fill still uses a logic similar to before, just with better visibility given to the outline instead of letting it disappear in dark colors.