### PR TITLE
Run `git_version_describe` in the source directory

### DIFF
--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -41,6 +41,7 @@ function(git_version_configure_file in_file out_file)
 					"-DGIT_VERSION_VAR=${ARG_VAR}"
 					"-DGIT_VERSION_FALLBACK=${PROJECT_VERSION}"
 					-P "${CMAKE_CURRENT_FUNCTION_LIST_FILE}"
+				WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 			)
 		else()
 			message(STATUS "Generating ${out_filename} with static version")


### PR DESCRIPTION
By default this runs in the build directory, and if the build directory is not a subdirectory of the source directory then the command will fail.