### PR TITLE
WIP: Add pixel rulers

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -368,6 +368,8 @@ target_sources(drawpile PRIVATE
 	widgets/recentscroll.h
 	widgets/resizerwidget.cpp
 	widgets/resizerwidget.h
+	widgets/rulerwidget.cpp
+	widgets/rulerwidget.h
 	widgets/serverlogview.cpp
 	widgets/serverlogview.h
 	widgets/spanawaretreeview.cpp

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -4058,6 +4058,7 @@ void MainWindow::setupActions()
 	QAction *evadeusercursors = makeAction("evadeusercursors", tr("Hide From Cursor")).noDefaultShortcut().checked().remembered();
 	QAction *showlasers = makeAction("showlasers", tr("Show La&ser Trails")).noDefaultShortcut().checked().remembered();
 	QAction *showgrid = makeAction("showgrid", tr("Show Pixel &Grid")).noDefaultShortcut().checked().remembered();
+	QAction *showrulers = makeAction("showrulers", tr("Show &Rulers")).noDefaultShortcut().checkable().remembered();
 
 #ifndef SINGLE_MAIN_WINDOW
 	QAction *fullscreen = makeAction("fullscreen", tr("&Full Screen")).shortcut(QKeySequence::FullScreen).checkable();
@@ -4111,7 +4112,7 @@ void MainWindow::setupActions()
 	m_canvasView->connectActions(
 		{moveleft, moveright, moveup, movedown, zoomin, zoomout, zoomorig,
 		 zoomfit, zoomfitwidth, zoomfitheight, rotateorig, rotatecw, rotateccw,
-		 viewflip, viewmirror, showgrid, showusermarkers, showusernames,
+		 viewflip, viewmirror, showgrid, showrulers, showusermarkers, showusernames,
 		 showuserlayers, showuseravatars, evadeusercursors});
 
 #ifndef SINGLE_MAIN_WINDOW
@@ -4211,6 +4212,7 @@ void MainWindow::setupActions()
 	viewmenu->addAction(showannotations);
 
 	viewmenu->addAction(showgrid);
+	viewmenu->addAction(showrulers);
 
 #ifndef SINGLE_MAIN_WINDOW
 	viewmenu->addSeparator();

--- a/src/desktop/view/canvasview.h
+++ b/src/desktop/view/canvasview.h
@@ -9,6 +9,7 @@ class QUrl;
 
 namespace widgets {
 class NotificationBar;
+class RulerWidget;
 }
 
 namespace view {
@@ -32,6 +33,7 @@ public:
 	void hideDisconnectedWarning();
 	void showResetNotice(bool compatibilityMode, bool saveInProgress);
 	void hideResetNotice();
+	void showRulers(bool enabled);
 
 signals:
 	void colorDropped(const QColor &color);
@@ -70,6 +72,7 @@ private:
 	void onControllerScrollAreaChanged(
 		int minH, int maxH, int valueH, int pageStepH, int singleStepH,
 		int minV, int maxV, int valueV, int pageStepV, int singleStepV);
+	void onViewChanged(const QPolygonF &view);
 
 	void activateNotificationBarAction();
 	void dismissNotificationBar();
@@ -79,6 +82,9 @@ private:
 	CanvasController *m_controller;
 	CanvasInterface *m_canvasWidget;
 	widgets::NotificationBar *m_notificationBar;
+	widgets::RulerWidget *m_hRuler;
+	widgets::RulerWidget *m_vRuler;
+	QWidget *m_corner;
 	NotificationBarState m_notificationBarState = NotificationBarState::None;
 	bool m_blockScrolling = false;
 	bool m_touchUseGestureEvents = false;

--- a/src/desktop/view/canvaswrapper.h
+++ b/src/desktop/view/canvaswrapper.h
@@ -62,6 +62,7 @@ public:
 		QAction *viewflip;
 		QAction *viewmirror;
 		QAction *showgrid;
+		QAction *showruler;
 		QAction *showusermarkers;
 		QAction *showusernames;
 		QAction *showuserlayers;

--- a/src/desktop/view/viewwrapper.cpp
+++ b/src/desktop/view/viewwrapper.cpp
@@ -220,6 +220,8 @@ void ViewWrapper::connectActions(const Actions &actions)
 		actions.showgrid, &QAction::toggled, m_controller,
 		&CanvasController::setPixelGrid);
 	connect(
+		actions.showruler, &QAction::toggled, m_view, &CanvasView::showRulers);
+	connect(
 		actions.showusermarkers, &QAction::toggled, m_scene,
 		&CanvasScene::setShowUserMarkers);
 	connect(

--- a/src/desktop/widgets/rulerwidget.cpp
+++ b/src/desktop/widgets/rulerwidget.cpp
@@ -99,13 +99,13 @@ void RulerWidget::paintEvent(QPaintEvent *)
 
 			if(lineHeight * digits >= pixelsPerRulerDivision - 2) {
 				QFont smallerFont = painter.font();
-				int newPointSize = smallerFont.pointSize() - 1;
-				if(newPointSize == 0)
+				qreal newPointSize = smallerFont.pointSizeF() - 1;
+				if(newPointSize <= 0)
 					// The font doesn't seem to be responding to point size or
 					// something else is wrong. Bail out here and continue with
 					// the current font.
 					break;
-				smallerFont.setPointSize(newPointSize);
+				smallerFont.setPointSizeF(newPointSize);
 				painter.setFont(smallerFont);
 			} else
 				break;
@@ -147,16 +147,22 @@ void RulerWidget::onViewChanged(const QPolygonF &view)
 		m_lMin = view.boundingRect().top();
 		m_lMax = view.boundingRect().bottom();
 	}
+	update();
 }
 
 void RulerWidget::setCanvasToRulerTransform(qreal scale, int offset)
 {
 	m_canvasToRulerScale = scale;
 	m_canvasToRulerOffset = offset;
+	update();
 }
 
 void RulerWidget::onTransformChanged(qreal zoom [[maybe_unused]], qreal angle)
 {
-	m_isRotated = std::abs(angle) > 0.001;
+	bool isRotated = std::abs(angle) > 0.001;
+	if(isRotated != m_isRotated) {
+		m_isRotated = isRotated;
+		update();
+	}
 }
 } // namespace widgets

--- a/src/desktop/widgets/rulerwidget.cpp
+++ b/src/desktop/widgets/rulerwidget.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "desktop/widgets/rulerwidget.h"
+
+#include <QPainter>
+
+#include <array>
+
+namespace widgets {
+static constexpr std::array niceDivisions{1,   2,	5,	 10,   20,	 50,
+										  100, 200, 500, 1000, 2000, 5000};
+
+
+RulerWidget::RulerWidget(QWidget *parent)
+	: QWidget(parent)
+{
+	// This widget does not yet support creating guides, so for now don't
+	// intercept mouse events to avoid confusion.
+	setAttribute(Qt::WA_TransparentForMouseEvents);
+}
+
+void RulerWidget::paintEvent(QPaintEvent *)
+{
+	QPainter painter(this);
+	painter.fillRect(0, 0, width(), height(), palette().color(QPalette::Light));
+
+	// The ruler doesn't make any sense right now for a rotated canvas, so
+	// disable it if the canvas is rotated.
+	// TODO: We could project the pixel grid to the ruler and draw ticks at the
+	//       intersection.
+	if(m_isRotated)
+		return;
+
+	// How many canvas pixels are in view.
+	qreal distance = m_lMax - m_lMin;
+	if(distance < 1)
+		return;
+
+	// We want about 60 display independent pixels per division.
+	int divisions = longSize() / 60;
+
+	qreal initialPPD = distance / divisions;
+	// Having weird numbers for divisions isn't great, so try to fit this to a
+	// nearby nice number.
+	int adjustedPPD = 1;
+	qreal bestDist = niceDivisions.back();
+	for(int ppd : niceDivisions) {
+		qreal dist = std::abs(initialPPD - ppd);
+		if(dist < bestDist) {
+			adjustedPPD = ppd;
+			bestDist = dist;
+		}
+	}
+
+	int pixelsPerRulerDivision =
+		std::lround((adjustedPPD * m_canvasToRulerScale));
+	divisions = longSize() / pixelsPerRulerDivision;
+
+	QColor dark = palette().color(QPalette::Dark);
+	QColor text = palette().color(QPalette::Text);
+
+	painter.setPen(dark);
+	painter.setRenderHint(QPainter::Antialiasing, true);
+	// Set pen for consistent line width on high DPI displays
+	QPen pen = painter.pen();
+	pen.setWidthF(1.0 / devicePixelRatioF());
+	painter.setPen(pen);
+
+	qreal startOffset = std::fmod(std::abs(m_lMin), adjustedPPD);
+	int canvasL = std::lround(
+		m_lMin < 0 ? (m_lMin + startOffset) - adjustedPPD
+				   : m_lMin - startOffset);
+
+	int lineHeight = 0;
+	if(!isHorizontal()) {
+		// Figure out the largest number we're going to draw so that we can
+		// choose a smaller font size if it's too big.
+		auto digitsNeeded = [&](int num) {
+			int negative = 0;
+			if(num < 0) {
+				num = -num;
+				negative = 1;
+			}
+			for(int i = 1; i <= std::numeric_limits<int>::digits10; ++i) {
+				if(num < std::pow(10, i))
+					return i + negative;
+			}
+			return std::numeric_limits<int>::digits10 + 1 + negative;
+		};
+
+		int digits = std::max(
+			digitsNeeded(canvasL),
+			digitsNeeded(canvasL + adjustedPPD * divisions));
+
+		while(true) {
+			lineHeight =
+				painter.fontMetrics().tightBoundingRect("0123456789").height();
+			lineHeight += 2;
+
+			if(lineHeight * digits >= pixelsPerRulerDivision - 2) {
+				QFont smallerFont = painter.font();
+				int newPointSize = smallerFont.pointSize() - 1;
+				if(newPointSize == 0)
+					// The font doesn't seem to be responding to point size or
+					// something else is wrong. Bail out here and continue with
+					// the current font.
+					break;
+				smallerFont.setPointSize(newPointSize);
+				painter.setFont(smallerFont);
+			} else
+				break;
+		}
+	}
+
+	for(;; canvasL += adjustedPPD) {
+		int l = canvasToRuler(canvasL);
+		if(l < -pixelsPerRulerDivision)
+			continue;
+		if(l >= longSize())
+			break;
+		painter.setPen(dark);
+		painter.drawLine(adjustPoint(l, 0), adjustPoint(l, shortSize()));
+		painter.setPen(text);
+		if(isHorizontal())
+			painter.drawText(
+				adjustPoint(l + 2, shortSize() - 2), QString::number(canvasL));
+		else {
+			// Qt can't draw anti-aliased texted when rotated, so draw it
+			// vertically. Also, we can't set the line spacing using drawText,
+			// so we get to draw each character manually.
+			QString label = QString::number(canvasL);
+			int offset = lineHeight;
+			for(QChar c : label) {
+				painter.drawText(2, l + offset, c);
+				offset += lineHeight;
+			}
+		}
+	}
+}
+
+void RulerWidget::onViewChanged(const QPolygonF &view)
+{
+	if(isHorizontal()) {
+		m_lMin = view.boundingRect().left();
+		m_lMax = view.boundingRect().right();
+	} else {
+		m_lMin = view.boundingRect().top();
+		m_lMax = view.boundingRect().bottom();
+	}
+}
+
+void RulerWidget::setCanvasToRulerTransform(qreal scale, int offset)
+{
+	m_canvasToRulerScale = scale;
+	m_canvasToRulerOffset = offset;
+}
+
+void RulerWidget::onTransformChanged(qreal zoom [[maybe_unused]], qreal angle)
+{
+	m_isRotated = std::abs(angle) > 0.001;
+}
+} // namespace widgets

--- a/src/desktop/widgets/rulerwidget.h
+++ b/src/desktop/widgets/rulerwidget.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RULERWIDGET_H
+#define RULERWIDGET_H
+
+#include <QWidget>
+
+#include <cmath>
+
+namespace widgets {
+
+class RulerWidget final : public QWidget {
+	Q_OBJECT
+public:
+	explicit RulerWidget(QWidget *parent = nullptr);
+
+	void onViewChanged(const QPolygonF &view);
+	void onTransformChanged(qreal zoom, qreal angle);
+	// Maps from a pixel on the canvas to a pixel on the ruler. Apply scale
+	// first, then offset.
+	void setCanvasToRulerTransform(qreal scale, int offset);
+
+protected:
+	void paintEvent(QPaintEvent *) override;
+
+private:
+	int longSize() const { return std::max(width(), height()); }
+	int shortSize() const { return std::min(width(), height()); }
+	bool isHorizontal() const { return width() > height(); }
+
+	QPoint adjustPoint(int longPos, int shortPos)
+	{
+		if(isHorizontal())
+			return {longPos, shortPos};
+		return {shortPos, longPos};
+	}
+
+	int canvasToRuler(qreal pos)
+	{
+		return std::lround((pos - m_lMin) * m_canvasToRulerScale) +
+			   m_canvasToRulerOffset;
+	}
+
+	qreal m_lMin = 0.;
+	qreal m_lMax = 0.;
+	qreal m_canvasToRulerScale = 1.;
+	int m_canvasToRulerOffset = 0;
+	bool m_isRotated = false;
+};
+
+} // namespace widgets
+
+#endif // RULERWIDGET_H


### PR DESCRIPTION
This adds pixel rulers to the top and left sides of the canvas. This is only implemented for the new renderer, as the previous renderer is going away eventually.

This handles auto scaling the division spacing and font size, and uses the current theme's colors for drawing the ruler.

Current issues:
* Not very pretty, would be nice to have someone mock up a better look.
* Does not support canvas rotation. Currently just turns off when the canvas is rotated.
