### PR TITLE
Changing phrasing from "confirmation" to "details"

### DIFF
--- a/src/desktop/dialogs/settingsdialog/userinterface.cpp
+++ b/src/desktop/dialogs/settingsdialog/userinterface.cpp
@@ -150,7 +150,7 @@ void UserInterface::initMiscellaneous(
 	form->addRow(tr("On-canvas notices:"), showTransformNotices);
 
 	QCheckBox *showFillNotices =
-		new QCheckBox(tr("Fill and magic wand confirmation"));
+		new QCheckBox(tr("Fill and magic wand details"));
 	settings.bindShowFillNotices(showFillNotices);
 	form->addRow(nullptr, showFillNotices);
 


### PR DESCRIPTION
Changing phrasing from "confirmation" to "details". Confirmation will be confused with the preview / brush confirmation mechanism, even if in the notice category.