### PR TITLE
OKLAB SIMD variants

### DIFF
--- a/src/desktop/i18n/drawpile_de_DE.ts
+++ b/src/desktop/i18n/drawpile_de_DE.ts
@@ -1216,7 +1216,9 @@ Teilreichweite: [%3, %4]</translation>
         <source>This session is hosted on another server, you will be redirected.
 
 To avoid this extra step in the future, use the Browse page or a direct link to a session instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Diese Sitzung ist auf einem anderen Server gehostet, Sie werden weitergeleitet.
+
+Um diesen zusätzlichen Schritt in Zukunft zu vermeiden, verwenden Sie stattdessen die Durchsuchen-Seite oder einen direkten Link zu einer Sitzung.</translation>
     </message>
     <message>
         <location line="-612"/>
@@ -2738,7 +2740,7 @@ Möchten Sie wirklich die Aufnahme von Debug-Dumps starten?</translation>
     <message>
         <location line="+6"/>
         <source>Left-handed mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Linkshändermodus</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -5561,52 +5563,52 @@ Deaktiviert bringt das Verhalten vor Drawpile 2.3 zurück.</translation>
     <message>
         <location line="-284"/>
         <source>No dynamics</source>
-        <translation type="unfinished">Keine Dynamik</translation>
+        <translation>Keine Dynamik</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Pressure dynamics</source>
-        <translation type="unfinished">Druckdynamik</translation>
+        <translation>Druckdynamik</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Velocity dynamics</source>
-        <translation type="unfinished">Geschwindigkeitsdynamik</translation>
+        <translation>Geschwindigkeitsdynamik</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Distance dynamics</source>
-        <translation type="unfinished">Distanzdynamik</translation>
+        <translation>Distanzdynamik</translation>
     </message>
     <message>
         <location line="+21"/>
         <source>Maximum Velocity: </source>
-        <translation type="unfinished">Maximale Geschwindigkeit: </translation>
+        <translation>Maximale Geschwindigkeit: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Maximum Distance: </source>
-        <translation type="unfinished">Maximale Distanz: </translation>
+        <translation>Maximale Distanz: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Set the maximum velocity for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Setzt die maximale Geschwindigkeit für Größe, Deckkraft, Härte, Schmieren und Zittern auf einmal.</translation>
+        <translation>Setzt die maximale Geschwindigkeit für Größe, Deckkraft, Härte, Schmieren und Zittern auf einmal.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum velocity set for all settings in this brush.</source>
-        <translation type="unfinished">Maximale Geschwindigkeit für alle Einstellungen dieses Pinsels angewendet.</translation>
+        <translation>Maximale Geschwindigkeit für alle Einstellungen dieses Pinsels angewendet.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Set the maximum distance for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Setzt die maximale Distanz für Größe, Deckkraft, Härte, Schmieren und Zittern auf einmal.</translation>
+        <translation>Setzt die maximale Distanz für Größe, Deckkraft, Härte, Schmieren und Zittern auf einmal.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum distance set for all settings in this brush.</source>
-        <translation type="unfinished">Maximale Distanz für alle Einstellungen dieses Pinsels angewendet.</translation>
+        <translation>Maximale Distanz für alle Einstellungen dieses Pinsels angewendet.</translation>
     </message>
     <message>
         <location line="+89"/>
@@ -7702,7 +7704,7 @@ Werte über 0.5 sind eventuell nicht visuell erkennbar.</translation>
     <message>
         <location line="+25"/>
         <source>(redirected from %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>(weitergeleitet von %1)</translation>
     </message>
     <message>
         <location line="+139"/>
@@ -12040,8 +12042,8 @@ Werte über 0.5 sind eventuell nicht visuell erkennbar.</translation>
         <source>Can&apos;t create another/%n more layer(s).</source>
         <extracomment>Singular should be &quot;can&apos;t create another layer&quot;, plural &quot;can&apos;t create %n more layers&quot;. Change this to make sense in your language.</extracomment>
         <translation>
-            <numerusform>Kann nicht noch eine Ebene erstellen,</numerusform>
-            <numerusform>Kann nicht noch %n Ebenen erstellen,</numerusform>
+            <numerusform>Kann nicht noch eine Ebene erstellen.</numerusform>
+            <numerusform>Kann nicht noch %n Ebenen erstellen.</numerusform>
         </translation>
     </message>
     <message>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -1215,7 +1215,9 @@ Sub-rango: [%3, %4]</translation>
         <source>This session is hosted on another server, you will be redirected.
 
 To avoid this extra step in the future, use the Browse page or a direct link to a session instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Esta sesión está alojada en otro servidor y será redirigido.
+
+Para evitar este paso adicional en el futuro, utilice la página Explorar o un enlace directo a una sesión.</translation>
     </message>
     <message>
         <location line="-612"/>
@@ -1841,7 +1843,7 @@ Simplify the canvas and reset manually before space runs out.</source>
     <message>
         <location line="+6"/>
         <source>Left-handed mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Modo para zurdos</translation>
     </message>
     <message>
         <location line="+23"/>
@@ -3667,12 +3669,12 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+42"/>
         <source>Could not write log file: %1</source>
-        <translation type="unfinished">No podía escribir archivo de historia: %1</translation>
+        <translation>No se pudo escribir el archivo de registro: %1</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>Could not read log file: %1</source>
-        <translation type="unfinished">No podía leer archivo de historia: %1</translation>
+        <translation>No pudo leer el archivo de registro: %1</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -3699,7 +3701,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
         <location filename="../utils/widgetutils.cpp" line="-92"/>
         <source>%1 (%2)</source>
         <extracomment>This makes an action and a keyboard shortcut, like &quot;Undo (Ctrl+Z)&quot;. %1 is the action, %2 is the shortcut. You only need to change this if your language uses different spaces or parentheses, otherwise just leave it as-is.</extracomment>
-        <translation type="unfinished">%1 (%2)</translation>
+        <translation>%1 (%2)</translation>
     </message>
 </context>
 <context>
@@ -3707,7 +3709,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+137"/>
         <source>None</source>
-        <translation type="unfinished">Ninguno</translation>
+        <translation>Ninguno</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -3722,7 +3724,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+6"/>
         <source>Blue</source>
-        <translation type="unfinished">Azul</translation>
+        <translation>Azul</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -3737,7 +3739,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+6"/>
         <source>Green</source>
-        <translation type="unfinished">Verde</translation>
+        <translation>Verde</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -4011,7 +4013,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+5"/>
         <source>Lasso Fill</source>
-        <translation type="unfinished">Relleno de lazo</translation>
+        <translation>Relleno de lazo</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -4051,7 +4053,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+5"/>
         <source>Transform</source>
-        <translation type="unfinished">Transformar</translation>
+        <translation>Transformar</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -4263,19 +4265,19 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
         <location line="+40"/>
         <location line="+125"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="-195"/>
         <location line="+247"/>
         <source>Operators: </source>
-        <translation type="unfinished">Operadores: </translation>
+        <translation>Operadores: </translation>
     </message>
     <message>
         <location line="-214"/>
         <location line="+201"/>
         <source>Trusted: </source>
-        <translation type="unfinished">De confianza: </translation>
+        <translation>De confianza: </translation>
     </message>
     <message>
         <location line="-178"/>
@@ -4286,7 +4288,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
         <location line="+17"/>
         <location line="+26"/>
         <source>Registered: </source>
-        <translation type="unfinished">Registrado: </translation>
+        <translation>Registrado: </translation>
     </message>
     <message>
         <location line="-7"/>
@@ -4297,7 +4299,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
         <location line="+30"/>
         <location line="+76"/>
         <source>Everyone: </source>
-        <translation type="unfinished">Todos: </translation>
+        <translation>Todos: </translation>
     </message>
     <message>
         <location line="-30"/>
@@ -4506,7 +4508,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+24"/>
         <source>Rendering</source>
-        <translation type="unfinished">Renderizado</translation>
+        <translation>Renderizado</translation>
     </message>
     <message>
         <location line="+15"/>
@@ -4872,7 +4874,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+1"/>
         <source>MP4 Video</source>
-        <translation type="unfinished">Video MP4</translation>
+        <translation>Video MP4</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -4882,7 +4884,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+12"/>
         <source>Format:</source>
-        <translation type="unfinished">Formato:</translation>
+        <translation>Formato:</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -4892,12 +4894,12 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+9"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Smooth</source>
-        <translation type="unfinished">Suavizado</translation>
+        <translation>Suavizado</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -4907,7 +4909,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+7"/>
         <source>Input</source>
-        <translation type="unfinished">Entrada</translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -4917,12 +4919,12 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+12"/>
         <source> FPS</source>
-        <translation type="unfinished"> FPS</translation>
+        <translation> FPS</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Framerate:</source>
-        <translation type="unfinished">Cuadros por segundo:</translation>
+        <translation>Cuadros por segundo:</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -4957,7 +4959,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+6"/>
         <source>Export</source>
-        <translation type="unfinished">Exportar</translation>
+        <translation>Exportar</translation>
     </message>
     <message>
         <location line="+125"/>
@@ -5030,12 +5032,12 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+7"/>
         <source>Layers</source>
-        <translation type="unfinished">Capas</translation>
+        <translation>Capas</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Import the layers of an ORA or PSD file as timeline frames.</source>
-        <translation type="unfinished">Importar las capas de un archivo ORA o PSD como fotogramas de la línea de tiempo.</translation>
+        <translation>Importar las capas de un archivo ORA o PSD como fotogramas de la línea de tiempo.</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -5056,7 +5058,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+9"/>
         <source> FPS</source>
-        <translation type="unfinished"> FPS</translation>
+        <translation> FPS</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -5184,7 +5186,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+1"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="+54"/>
@@ -5320,7 +5322,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+5"/>
         <source>Thumbnail:</source>
-        <translation type="unfinished">Miniatura:</translation>
+        <translation>Miniatura:</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -5330,12 +5332,12 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+8"/>
         <source>Name:</source>
-        <translation type="unfinished">Nombre:</translation>
+        <translation>Nombre:</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Description:</source>
-        <translation type="unfinished">Descripcion:</translation>
+        <translation>Descripción:</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -5363,7 +5365,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
     <message>
         <location line="+121"/>
         <source>Brush</source>
-        <translation type="unfinished">Pincel</translation>
+        <translation>Pincel</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -5596,42 +5598,42 @@ Al desactivarla, el comportamiento se restablece a su estado anterior a Drawpile
         <location line="+12"/>
         <location line="+306"/>
         <source>Jitter</source>
-        <translation type="unfinished">Temblor</translation>
+        <translation>Desviación</translation>
     </message>
     <message>
         <location line="-284"/>
         <source>No dynamics</source>
-        <translation type="unfinished">Sin Dynamicas</translation>
+        <translation>Sin Dinámicas</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Pressure dynamics</source>
-        <translation type="unfinished">Dinámicas de presión</translation>
+        <translation>Dinámicas de presión</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Velocity dynamics</source>
-        <translation type="unfinished">Dinámicas de velocidad</translation>
+        <translation>Dinámicas de velocidad</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Distance dynamics</source>
-        <translation type="unfinished">Dinámicas de distancia</translation>
+        <translation>Dinámicas de distancia</translation>
     </message>
     <message>
         <location line="+21"/>
         <source>Maximum Velocity: </source>
-        <translation type="unfinished">Velocidad Maxima: </translation>
+        <translation>Velocidad Maxima: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Maximum Distance: </source>
-        <translation type="unfinished">Distancia Maxima: </translation>
+        <translation>Distancia Maxima: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Set the maximum velocity for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Manchas y Vibración a la vez.</translation>
+        <translation>Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Manchas y Desviación a la vez.</translation>
     </message>
     <message>
         <location line="+14"/>
@@ -7702,7 +7704,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+25"/>
         <source>(redirected from %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>(redirigido desde %1)</translation>
     </message>
     <message>
         <location line="+139"/>
@@ -8490,7 +8492,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+12"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
 </context>
 <context>
@@ -8684,7 +8686,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+15"/>
         <source>Copy</source>
-        <translation type="unfinished">Copiar</translation>
+        <translation>Copiar</translation>
     </message>
 </context>
 <context>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -6669,7 +6669,7 @@ Para velocidades muy lentas, ocurre lo opuesto.</translation>
         <translation>Añade un desplazamiento aleatorio a la posición donde se dibuja cada pincelada.­
  0.0 desactivado.
  1.0 desviación estándar equivale a un radio básico.
-&lt;0.0: valores negativos no producen Desviación/Fluctuación.</translation>
+&lt;0.0: valores negativos no producen Desviación/Fluctuación</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -6973,10 +6973,8 @@ The range is 0-5x.
 This allows you to stretch or compress the GridMap pattern.</source>
         <comment>mypaintsetting</comment>
         <extracomment>This text comes from the MyPaint brush engine. You can skip translating it if it&apos;s too difficult.</extracomment>
-        <translation type="unfinished">Cambia la escala en la que opera el pincel de GridMap; afecta solo al eje X.
-
+        <translation>Cambia la escala en la que opera el pincel de GridMap; afecta solo al eje X.
 El rango es de 0 a 5x.
-
 Esto permite estirar o comprimir el patrón de GridMap.</translation>
     </message>
     <message>
@@ -7310,12 +7308,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>&amp;Trusted</source>
-        <translation type="unfinished">&amp;Confiado</translation>
+        <translation>&amp;Confianza</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>&amp;Operator</source>
-        <translation type="unfinished">&amp;Operador</translation>
+        <translation>&amp;Operador</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -7385,7 +7383,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>Smooth In</source>
-        <translation type="unfinished">Suavizar</translation>
+        <translation>Suavizar En</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7525,32 +7523,32 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/layerproperties.cpp" line="+122"/>
         <source>New Layer Group</source>
-        <translation type="unfinished">Nuevo Grupo de Capas</translation>
+        <translation>Nuevo Grupo de Capas</translation>
     </message>
     <message>
         <location line="+0"/>
         <source>New Layer</source>
-        <translation type="unfinished">Nueva Capa</translation>
+        <translation>Nueva Capa</translation>
     </message>
     <message>
         <location filename="../utils/blendmodes.cpp" line="+113"/>
         <source>Pass Through</source>
-        <translation type="unfinished">Pasar Atravez</translation>
+        <translation>Transparente/Pasar a Través</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="-1022"/>
         <source>Blend alpha</source>
-        <translation type="unfinished">Mezcla alfa</translation>
+        <translation>Mezcla alfa</translation>
     </message>
     <message>
         <location line="+8"/>
         <source>Inherit alpha</source>
-        <translation type="unfinished">Heredar alfa</translation>
+        <translation>Heredar alfa</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Clip to layer below</source>
-        <translation type="unfinished">Recortar a la capa inferior</translation>
+        <translation>Fijar a la capa inferior</translation>
     </message>
 </context>
 <context>
@@ -7975,13 +7973,13 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/selectionalterdialog.cpp" line="+40"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="-1"/>
         <source>Feather: </source>
         <extracomment>&quot;Feather&quot; is a verb here, referring to blurring the selection.</extracomment>
-        <translation type="unfinished">Pluma: </translation>
+        <translation>Difuminar: </translation>
     </message>
     <message>
         <location line="+49"/>
@@ -8351,7 +8349,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -8371,17 +8369,17 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+41"/>
         <source>Custom</source>
-        <translation type="unfinished">Personalizado</translation>
+        <translation>Personalizado</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Hue</source>
-        <translation type="unfinished">Tono</translation>
+        <translation>Tono</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Saturation</source>
-        <translation type="unfinished">Saturación</translation>
+        <translation>Saturación</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -8391,12 +8389,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Value</source>
-        <translation type="unfinished">Valor</translation>
+        <translation>Valor</translation>
     </message>
     <message>
         <location line="+0"/>
         <source>Lightness</source>
-        <translation type="unfinished">Luminosidad</translation>
+        <translation>Luminosidad</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -8411,12 +8409,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+13"/>
         <source>Move Up</source>
-        <translation type="unfinished">Mover hacia arriba</translation>
+        <translation>Mover hacia arriba</translation>
     </message>
     <message>
         <location line="+12"/>
         <source>Move Down</source>
-        <translation type="unfinished">Mover hacia abajo</translation>
+        <translation>Mover hacia abajo</translation>
     </message>
     <message>
         <location line="+122"/>
@@ -8477,7 +8475,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Value offset: </source>
-        <translation type="unfinished">Desplazamiento de valor: </translation>
+        <translation>Desplazamiento de valor: </translation>
     </message>
     <message>
         <location line="+0"/>
@@ -8847,17 +8845,17 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/settingsdialog/files.cpp" line="+42"/>
         <source>When enabled, save every %1 minutes</source>
-        <translation type="unfinished">Cuando esta habilitado, guardar cada %1 minutos</translation>
+        <translation>Cuando esta habilitado, guardar cada %1 minutos</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Autosave:</source>
-        <translation type="unfinished">guardado automatice:</translation>
+        <translation>guardado automático:</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Autosave can be enabled for the current file under File ▸ Autosave.</source>
-        <translation type="unfinished">Guardado automático puede ser habilitado para el archivo actual bajo Archivo ▸ guardado automático.</translation>
+        <translation>El Guardado automático puede ser habilitado para el archivo actual bajo Archivo ▸ guardado automático.</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -8984,7 +8982,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+3"/>
         <source>Default</source>
         <extracomment>One of the canvas renderer options.</extracomment>
-        <translation type="unfinished">Predeterminado</translation>
+        <translation>Predeterminado</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -8996,7 +8994,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <source>Unknown</source>
         <comment>CanvasImplementation</comment>
         <extracomment>Refers to an unknown canvas renderer, should never happen.</extracomment>
-        <translation type="unfinished">Desconocido</translation>
+        <translation>Desconocido</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -9199,17 +9197,17 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>System</source>
-        <translation type="unfinished">Sistema</translation>
+        <translation>Sistema</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Disabled</source>
-        <translation type="unfinished">Deshabilitado</translation>
+        <translation>Deshabilitado</translation>
     </message>
     <message>
         <location line="+8"/>
         <source>Receive delay:</source>
-        <translation type="unfinished">Recibir retrasos:</translation>
+        <translation>Recibir retrasos:</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -9239,7 +9237,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Remove</source>
-        <translation type="unfinished">Remover</translation>
+        <translation>Remover</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -9300,7 +9298,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Bounce dock</source>
-        <translation type="unfinished">Rebotar dock</translation>
+        <translation>Panel de Rebote</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -9580,7 +9578,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="-53"/>
         <location line="+58"/>
         <source>Remove</source>
-        <translation type="unfinished">Remover</translation>
+        <translation>Remover</translation>
     </message>
     <message>
         <location line="-54"/>
@@ -9667,12 +9665,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+123"/>
         <location line="+27"/>
         <source>Edit Canvas Shortcut</source>
-        <translation type="unfinished">Editar Atajo de Lienzo</translation>
+        <translation>Editar Atajo de Lienzo</translation>
     </message>
     <message>
         <location line="-17"/>
         <source>Add canvas shortcut…</source>
-        <translation type="unfinished">Añadir atajos de lienzo…</translation>
+        <translation>Añadir atajos de lienzo…</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -9682,7 +9680,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>New Canvas Shortcut</source>
-        <translation type="unfinished">Nuevo Atajo de Lienzo</translation>
+        <translation>Nuevo Atajo de Lienzo</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -9697,22 +9695,22 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+15"/>
         <source>Remove selected canvas shortcut…</source>
-        <translation type="unfinished">Remover atajos de lienzo seleccionados…</translation>
+        <translation>Remover atajos de lienzo seleccionados…</translation>
     </message>
     <message>
         <location line="+0"/>
         <source>Remove</source>
-        <translation type="unfinished">Remover</translation>
+        <translation>Remover</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Remove canvas shortcut</source>
-        <translation type="unfinished">Remover atajos de lienzo</translation>
+        <translation>Remover atajos de lienzo</translation>
     </message>
     <message numerus="yes">
         <location line="+1"/>
         <source>Really remove %n canvas shortcut(s)?</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>¿Realmente deseas remover %n atajo de lienzo?</numerusform>
             <numerusform>¿Realmente deseas remover %n atajos de lienzo?</numerusform>
         </translation>
@@ -9720,12 +9718,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+7"/>
         <source>Restore Canvas Shortcut Defaults</source>
-        <translation type="unfinished">Restaurar Atajos de Lienzo por Defecto</translation>
+        <translation>Restaurar Atajos de Lienzo por Defecto</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Really restore all canvas shortcuts to their default values?</source>
-        <translation type="unfinished">¿Realmente deseas restaurar todos los atajos de lienzo a sus valores por defecto?</translation>
+        <translation>¿Realmente deseas restaurar todos los atajos de lienzo a sus valores por defecto?</translation>
     </message>
     <message>
         <location line="+95"/>
@@ -9735,7 +9733,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+5"/>
         <source>Brushes</source>
-        <translation type="unfinished">Pinceles</translation>
+        <translation>Pinceles</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -9760,7 +9758,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+26"/>
         <location line="+20"/>
         <source>Output</source>
-        <translation type="unfinished">Salida</translation>
+        <translation>Salida</translation>
     </message>
     <message>
         <location line="-20"/>
@@ -9770,7 +9768,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Global pressure curve:</source>
-        <translation type="unfinished">Presión de curva global:</translation>
+        <translation>Presión de curva global:</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -9785,19 +9783,19 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Eraser</source>
-        <translation type="unfinished">Borrador</translation>
+        <translation>Borrador</translation>
     </message>
     <message>
         <location line="+21"/>
         <location filename="../mainwindow.cpp" line="-593"/>
         <source>Windows Ink</source>
-        <translation type="unfinished">Tinta de Windows</translation>
+        <translation>Tinta de Windows</translation>
     </message>
     <message>
         <location line="+3"/>
         <location filename="../mainwindow.cpp" line="+8"/>
         <source>Windows Ink Non-Native</source>
-        <translation type="unfinished">Windows Ink no nativo</translation>
+        <translation>Windows Ink no nativo</translation>
     </message>
     <message>
         <location line="+3"/>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -5633,7 +5633,7 @@ Al desactivarla, el comportamiento se restablece a su estado anterior a Drawpile
     <message>
         <location line="+11"/>
         <source>Set the maximum velocity for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation>Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Suavizado y Desviación a la vez.</translation>
+        <translation>Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Difuminado y Desviación a la vez.</translation>
     </message>
     <message>
         <location line="+14"/>
@@ -5643,12 +5643,12 @@ Al desactivarla, el comportamiento se restablece a su estado anterior a Drawpile
     <message>
         <location line="+6"/>
         <source>Set the maximum distance for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Establezca la distancia máxima para Tamaño, Opacidad, Dureza, Difuminado y Vibración a la vez.</translation>
+        <translation>Establezca la distancia máxima para Tamaño, Opacidad, Dureza, Difuminado y Desviación a la vez.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum distance set for all settings in this brush.</source>
-        <translation type="unfinished">Distancia máxima establecida para todos los ajustes de este Pincel.</translation>
+        <translation>Distancia máxima establecida para todos los ajustes de este Pincel.</translation>
     </message>
     <message>
         <location line="+89"/>
@@ -5695,7 +5695,7 @@ Si los trazos rápidos causan alteraciones no deseadas al difuminar, activar est
     <message>
         <location line="-345"/>
         <source>Preserve alpha</source>
-        <translation type="unfinished">Preservar alfa</translation>
+        <translation>Preservar alfa</translation>
     </message>
     <message>
         <location line="+823"/>
@@ -6666,10 +6666,10 @@ Para velocidades muy lentas, ocurre lo opuesto.</translation>
 &lt;0.0 negative values produce no jitter</source>
         <comment>mypaintsetting</comment>
         <extracomment>This text comes from the MyPaint brush engine. You can skip translating it if it&apos;s too difficult.</extracomment>
-        <translation type="unfinished">Añade un desplazamiento aleatorio a la posición donde se dibuja cada pincelada.­
+        <translation>Añade un desplazamiento aleatorio a la posición donde se dibuja cada pincelada.­
  0.0 desactivado.
  1.0 desviación estándar equivale a un radio básico.
-&lt;0.0: valores negativos no producen fluctuación.</translation>
+&lt;0.0: valores negativos no producen Desviación/Fluctuación.</translation>
     </message>
     <message>
         <location line="+3"/>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -10156,7 +10156,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+2"/>
         <source>Pan canvas</source>
-        <translation>Alejar lienzo</translation>
+        <translation>Mover lienzo</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -10171,7 +10171,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+7"/>
         <source>Zoom</source>
-        <translation type="unfinished">Acercar</translation>
+        <translation>Acercar</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -10201,12 +10201,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Smoothing:</source>
-        <translation type="unfinished">Suavizado:</translation>
+        <translation>Suavizado:</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
 </context>
 <context>
@@ -10300,12 +10300,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+57"/>
         <source>First checker color</source>
-        <translation type="unfinished">Primer color del damero</translation>
+        <translation>Primer color del damero</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Second checker color</source>
-        <translation type="unfinished">Segundo color del damero</translation>
+        <translation>Segundo color del damero</translation>
     </message>
     <message>
         <location line="+12"/>
@@ -10350,7 +10350,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Scaling:</source>
-        <translation type="unfinished">Escalado:</translation>
+        <translation>Escalado:</translation>
     </message>
     <message>
         <location line="+20"/>
@@ -10360,7 +10360,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="+19"/>
@@ -10375,12 +10375,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>Enabled</source>
-        <translation type="unfinished">Habilitado</translation>
+        <translation>Habilitado</translation>
     </message>
     <message>
         <location line="+0"/>
         <source>System</source>
-        <translation type="unfinished">Sistema</translation>
+        <translation>Sistema</translation>
     </message>
     <message>
         <location line="+16"/>
@@ -10540,7 +10540,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/startdialog/host.cpp" line="+41"/>
         <source>Session</source>
-        <translation type="unfinished">Sesion</translation>
+        <translation>Sesión</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -10550,17 +10550,17 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Permissions</source>
-        <translation type="unfinished">Permisos</translation>
+        <translation>Permisos</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Roles</source>
-        <translation type="unfinished">Roles</translation>
+        <translation>Roles</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Bans</source>
-        <translation type="unfinished">Baneos</translation>
+        <translation>Baneos</translation>
     </message>
     <message>
         <location line="+51"/>
@@ -10758,7 +10758,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+30"/>
         <source>Remove</source>
-        <translation type="unfinished">Remover</translation>
+        <translation>Remover</translation>
     </message>
 </context>
 <context>
@@ -10766,7 +10766,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/startdialog/host/categories.cpp" line="+27"/>
         <source>Session</source>
-        <translation type="unfinished">Sesion</translation>
+        <translation>Sesión</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -10781,12 +10781,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+7"/>
         <source>Permissions</source>
-        <translation type="unfinished">Permisos</translation>
+        <translation>Permisos</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Roles</source>
-        <translation type="unfinished">Roles</translation>
+        <translation>Roles</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -10796,7 +10796,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+7"/>
         <source>Bans</source>
-        <translation type="unfinished">Baneos</translation>
+        <translation>Baneos</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -10855,7 +10855,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>Title:</source>
-        <translation type="unfinished">Titulo:</translation>
+        <translation>Titulo:</translation>
     </message>
     <message>
         <location line="+11"/>
@@ -10880,7 +10880,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+5"/>
         <source>Remove selected</source>
-        <translation type="unfinished">Remover seleccionados</translation>
+        <translation>Remover seleccionados</translation>
     </message>
     <message>
         <location line="+139"/>
@@ -10909,13 +10909,13 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+37"/>
         <location line="+109"/>
         <source>Rename</source>
-        <translation type="unfinished">Renombrar</translation>
+        <translation>Renombrar</translation>
     </message>
     <message>
         <location line="-102"/>
         <location line="+140"/>
         <source>Delete</source>
-        <translation type="unfinished">Borrar</translation>
+        <translation>Borrar</translation>
     </message>
     <message>
         <location line="-131"/>
@@ -10964,7 +10964,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/startdialog/host/permissions.cpp" line="+107"/>
         <source>Undo Limit: </source>
-        <translation type="unfinished">Limite de Deshacer </translation>
+        <translation>Limite de Deshacer </translation>
     </message>
     <message>
         <location line="+16"/>
@@ -11050,12 +11050,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+296"/>
         <source>Everyone</source>
-        <translation type="unfinished">Todos</translation>
+        <translation>Todos</translation>
     </message>
     <message>
         <location line="+8"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="-10"/>
@@ -11070,7 +11070,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="-2"/>
         <source>Operators</source>
-        <translation type="unfinished">Operadores</translation>
+        <translation>Operadores</translation>
     </message>
 </context>
 <context>
@@ -11096,7 +11096,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>Operator password:</source>
-        <translation type="unfinished">Contraseña de operador:</translation>
+        <translation>Contraseña de operador:</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -11106,7 +11106,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+47"/>
         <source>Operator</source>
-        <translation type="unfinished">Operador</translation>
+        <translation>Operador</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -11124,7 +11124,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+14"/>
         <source>Name:</source>
-        <translation type="unfinished">Nombre:</translation>
+        <translation>Nombre:</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -11134,7 +11134,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+28"/>
         <source>Save</source>
-        <translation type="unfinished">Guardar</translation>
+        <translation>Guardar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -11182,7 +11182,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Generate</source>
-        <translation type="unfinished">Generar</translation>
+        <translation>Generar</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -11192,7 +11192,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Keep chat history</source>
-        <translation type="unfinished">Mantener historial de chat</translation>
+        <translation>Mantener historial de chat</translation>
     </message>
     <message>
         <location line="+14"/>
@@ -11458,7 +11458,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+3"/>
         <location line="+45"/>
         <source>Delete</source>
-        <translation type="unfinished">Borrar</translation>
+        <translation>Borrar</translation>
     </message>
     <message>
         <location line="-3"/>
@@ -11509,7 +11509,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Palette</source>
-        <translation type="unfinished">Paleta</translation>
+        <translation>Paleta</translation>
     </message>
     <message>
         <location line="+14"/>
@@ -11643,7 +11643,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Sliders</source>
-        <translation type="unfinished">Controles Deslizantes</translation>
+        <translation>Controles Deslizantes</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -11827,22 +11827,22 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Wheel</source>
-        <translation type="unfinished">Rueda</translation>
+        <translation>Rueda</translation>
     </message>
     <message>
         <location line="+110"/>
         <source>Direction</source>
-        <translation type="unfinished">Direccion</translation>
+        <translation>Dirección</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Ascending</source>
-        <translation type="unfinished">Ascendente</translation>
+        <translation>Ascendente</translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Descending</source>
-        <translation type="unfinished">Descendente</translation>
+        <translation>Descendente</translation>
     </message>
     <message>
         <location line="+11"/>
@@ -11852,7 +11852,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+3"/>
         <source>Top</source>
-        <translation type="unfinished">Cima</translation>
+        <translation>Cima</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -12116,7 +12116,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="-10"/>
         <source>Onion Skins</source>
-        <translation type="unfinished">Piel de Cebolla</translation>
+        <translation>Piel de Cebolla</translation>
     </message>
     <message>
         <location line="+27"/>
@@ -12164,7 +12164,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+6"/>
         <source>Paste</source>
-        <translation type="unfinished">Pegar</translation>
+        <translation>Pegar</translation>
     </message>
     <message>
         <location line="+2"/>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -12116,7 +12116,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="-10"/>
         <source>Onion Skins</source>
-        <translation>Piel de Cebolla</translation>
+        <translation>Pieles de Cebolla</translation>
     </message>
     <message>
         <location line="+27"/>
@@ -12174,7 +12174,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+5"/>
         <source>Close</source>
-        <translation type="unfinished">Cerrar</translation>
+        <translation>Cerrar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12209,12 +12209,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="+90"/>
         <source>Error</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12369,7 +12369,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+2"/>
         <source>Smooth</source>
-        <translation type="unfinished">Suavizado</translation>
+        <translation>Suavizado</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12446,7 +12446,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+1"/>
         <location filename="../toolwidgets/lassofillsettings.cpp" line="+2"/>
         <source>Average Smoothing</source>
-        <translation type="unfinished">Suavizado Promedio</translation>
+        <translation>Suavizado por Promedio</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12488,7 +12488,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+28"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -12589,7 +12589,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Opacity: </source>
-        <translation type="unfinished">Opacidad: </translation>
+        <translation>Opacidad: </translation>
     </message>
     <message>
         <location line="+111"/>
@@ -12616,7 +12616,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+11"/>
         <location line="+44"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="-45"/>
@@ -12626,7 +12626,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+10"/>
         <source>Linear</source>
-        <translation type="unfinished">Lineal</translation>
+        <translation>Lineal</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12681,12 +12681,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+31"/>
         <source>Mode:</source>
-        <translation type="unfinished">Modo:</translation>
+        <translation>Modo:</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Apply</source>
-        <translation type="unfinished">Aplicar</translation>
+        <translation>Aplicar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12696,7 +12696,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12739,7 +12739,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+65"/>
         <source>Mode:</source>
-        <translation type="unfinished">Modo:</translation>
+        <translation>Modo:</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12754,7 +12754,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Apply</source>
-        <translation type="unfinished">Aplicar</translation>
+        <translation>Aplicar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12764,7 +12764,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12860,7 +12860,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+14"/>
         <source>Nearest</source>
-        <translation type="unfinished">Mas cercano</translation>
+        <translation>Mas cercano</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12896,7 +12896,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+10"/>
         <source>Scale</source>
-        <translation type="unfinished">Escala</translation>
+        <translation>Escala</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12906,7 +12906,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+8"/>
         <source>Distort</source>
-        <translation type="unfinished">Distorcionar</translation>
+        <translation>Distorcionar</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -12922,7 +12922,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+15"/>
         <source>Mode:</source>
-        <translation type="unfinished">Modo:</translation>
+        <translation>Modo:</translation>
     </message>
     <message>
         <location line="+35"/>
@@ -12937,12 +12937,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+10"/>
         <source>Opacity: </source>
-        <translation type="unfinished">Opacidad: </translation>
+        <translation>Opacidad: </translation>
     </message>
     <message>
         <location line="+1"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -12957,7 +12957,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+9"/>
         <source>Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -12991,7 +12991,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../view/canvasscene.cpp" line="+603"/>
         <source>Restoring canvas…</source>
-        <translation type="unfinished">Restaurando Lienzo…</translation>
+        <translation>Restaurando Lienzo…</translation>
     </message>
     <message>
         <location line="+32"/>
@@ -13009,7 +13009,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../view/canvasview.cpp" line="+128"/>
         <source>Save As…</source>
-        <translation type="unfinished">Guardar como…</translation>
+        <translation>Guardar como…</translation>
     </message>
 </context>
 <context>
@@ -13022,42 +13022,42 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Reset in progress</source>
-        <translation type="unfinished">Reinicio en progreso</translation>
+        <translation>Reinicio en progreso</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Canvas is locked</source>
-        <translation type="unfinished">Lienzo bloqueado</translation>
+        <translation>Lienzo bloqueado</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>User is locked</source>
-        <translation type="unfinished">Usuario bloqueado</translation>
+        <translation>Usuario bloqueado</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Layer is a group</source>
-        <translation type="unfinished">La capa es un grupo</translation>
+        <translation>La capa es un grupo</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Layer is locked</source>
-        <translation type="unfinished">Capa bloqueada</translation>
+        <translation>Capa bloqueada</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Layer is censored</source>
-        <translation type="unfinished">Capa censurada</translation>
+        <translation>Capa censurada</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Layer is hidden</source>
-        <translation type="unfinished">La capa esta escondida</translation>
+        <translation>La capa esta escondida</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Layer is not visible in this frame</source>
-        <translation type="unfinished">La capa no es visible en este cuadro</translation>
+        <translation>La capa no es visible en este cuadro</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -13067,7 +13067,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Tool is locked</source>
-        <translation type="unfinished">La herramienta esta blockeada</translation>
+        <translation>La herramienta esta blockeada</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -13454,17 +13454,17 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../widgets/expandshrinkspinner.cpp" line="+27"/>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <location line="+18"/>
         <source>Expand</source>
-        <translation type="unfinished">Expandir</translation>
+        <translation>Expandir</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Shrink</source>
-        <translation type="unfinished">Contraer</translation>
+        <translation>Contraer</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -13484,7 +13484,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+0"/>
         <source>Expand: </source>
-        <translation type="unfinished">Expandir: </translation>
+        <translation>Expandir: </translation>
     </message>
 </context>
 <context>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -9789,7 +9789,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+21"/>
         <location filename="../mainwindow.cpp" line="-593"/>
         <source>Windows Ink</source>
-        <translation>Tinta de Windows</translation>
+        <translation>Windows Ink</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -9813,13 +9813,13 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
         <location line="+3"/>
         <location filename="../mainwindow.cpp" line="+10"/>
         <source>Qt5</source>
-        <translation type="unfinished">Qt5</translation>
+        <translation>Qt5</translation>
     </message>
     <message>
         <location line="+3"/>
         <location filename="../mainwindow.cpp" line="+9"/>
         <source>Qt6 Windows Ink</source>
-        <translation type="unfinished">Tinte Qt6 Windows</translation>
+        <translation>Qt6 Windows Ink</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -9835,7 +9835,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+2"/>
         <source>Enable pressure sensitivity</source>
-        <translation type="unfinished">Permitir sensibilidad de presión</translation>
+        <translation>Permitir sensibilidad de presión</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -9850,7 +9850,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+2"/>
         <source>Smoothing:</source>
-        <translation type="unfinished">Suavizado:</translation>
+        <translation>Suavizado:</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -9860,7 +9860,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+4"/>
         <source>Compensate jagged curves</source>
-        <translation type="unfinished">Compensar curvas dentadas</translation>
+        <translation>Compensar curvas irregulares</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -9965,7 +9965,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+1"/>
         <source>Arrow</source>
-        <translation type="unfinished">Puntero</translation>
+        <translation>Puntero/Flecha</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -10034,7 +10034,7 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+56"/>
         <source>Eraser</source>
-        <translation type="unfinished">Borrador</translation>
+        <translation>Borrador</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -10057,22 +10057,22 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location filename="../dialogs/settingsdialog/touch.cpp" line="+26"/>
         <source>Touch Tester</source>
-        <translation type="unfinished">Probador Tactil</translation>
+        <translation>Probador Tactil</translation>
     </message>
     <message>
         <location line="+29"/>
         <source>Touch mode:</source>
-        <translation type="unfinished">Modo táctil:</translation>
+        <translation>Modo táctil:</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Touchscreen</source>
-        <translation type="unfinished">Pantalla táctil</translation>
+        <translation>Pantalla táctil</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Gestures</source>
-        <translation type="unfinished">Gestos</translation>
+        <translation>Gestos</translation>
     </message>
     <message>
         <location line="+15"/>
@@ -10086,12 +10086,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="-82"/>
         <source>Undo</source>
-        <translation type="unfinished">Deshacer</translation>
+        <translation>Deshacer</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Redo</source>
-        <translation type="unfinished">Rehacer</translation>
+        <translation>Rehacer</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -10151,12 +10151,12 @@ Los valores superiores a 0,5 pueden pasar desapercibidos.</translation>
     <message>
         <location line="+11"/>
         <source>Draw</source>
-        <translation type="unfinished">Dibujar</translation>
+        <translation>Dibujar</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Pan canvas</source>
-        <translation type="unfinished">Alejar lienzo</translation>
+        <translation>Alejar lienzo</translation>
     </message>
     <message>
         <location line="+2"/>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -5249,7 +5249,7 @@ La grabación del volcado de depuración comenzara en el siguiente reinicio de l
         <location line="-6"/>
         <source>Couldn&apos;t read image: %1.</source>
         <extracomment>%1 is an error message.</extracomment>
-        <translation>No se puede leer la imagen: %1</translation>
+        <translation>No se puede leer la imagen: %1.</translation>
     </message>
     <message>
         <location line="+6"/>

--- a/src/desktop/i18n/drawpile_es_CO.ts
+++ b/src/desktop/i18n/drawpile_es_CO.ts
@@ -5633,12 +5633,12 @@ Al desactivarla, el comportamiento se restablece a su estado anterior a Drawpile
     <message>
         <location line="+11"/>
         <source>Set the maximum velocity for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation>Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Manchas y Desviación a la vez.</translation>
+        <translation>Establezca la velocidad máxima para Tamaño, Opacidad, Dureza, Suavizado y Desviación a la vez.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum velocity set for all settings in this brush.</source>
-        <translation type="unfinished">Velocidad máxima establecida para todos los ajustes de este pincel.</translation>
+        <translation>Velocidad máxima establecida para todos los ajustes de este pincel.</translation>
     </message>
     <message>
         <location line="+6"/>

--- a/src/desktop/i18n/drawpile_ja_JP.ts
+++ b/src/desktop/i18n/drawpile_ja_JP.ts
@@ -2377,7 +2377,7 @@ Are you sure youwant to start recording debug dumps?</source>
     <message>
         <location line="+6"/>
         <source>Left-handed mode</source>
-        <translation type="unfinished"></translation>
+        <translation>左手モード</translation>
     </message>
     <message>
         <location line="+17"/>

--- a/src/desktop/i18n/drawpile_uk_UA.ts
+++ b/src/desktop/i18n/drawpile_uk_UA.ts
@@ -1215,7 +1215,9 @@ Subrange: [%3, %4]</source>
         <source>This session is hosted on another server, you will be redirected.
 
 To avoid this extra step in the future, use the Browse page or a direct link to a session instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Цей сеанс розміщено на іншому сервері, вас буде перенаправлено.
+
+Щоб уникнути цього додаткового кроку в майбутньому, скористайтеся сторінкою перегляду або прямим посиланням на сеанс.</translation>
     </message>
     <message>
         <location line="-612"/>
@@ -2882,7 +2884,7 @@ Are you sure youwant to start recording debug dumps?</source>
     <message>
         <location line="+6"/>
         <source>Left-handed mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Режим для лівшів</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -5605,52 +5607,52 @@ Disabling it reverts the behavior to how it was before Drawpile 2.3.</source>
     <message>
         <location line="-284"/>
         <source>No dynamics</source>
-        <translation type="unfinished">Без динаміки</translation>
+        <translation>Без динаміки</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Pressure dynamics</source>
-        <translation type="unfinished">Динаміка тиску</translation>
+        <translation>Динаміка тиску</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Velocity dynamics</source>
-        <translation type="unfinished">Динаміка швидкості</translation>
+        <translation>Динаміка швидкості</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Distance dynamics</source>
-        <translation type="unfinished">Динаміка відстані</translation>
+        <translation>Динаміка відстані</translation>
     </message>
     <message>
         <location line="+21"/>
         <source>Maximum Velocity: </source>
-        <translation type="unfinished">Максимальна швидкість: </translation>
+        <translation>Максимальна швидкість: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Maximum Distance: </source>
-        <translation type="unfinished">Максимальна відстань: </translation>
+        <translation>Максимальна відстань: </translation>
     </message>
     <message>
         <location line="+11"/>
         <source>Set the maximum velocity for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Встановіть максимальну швидкість для розміру, непрозорості, твердості, розмазування та тремтіння одночасно.</translation>
+        <translation>Встановіть максимальну швидкість для розміру, непрозорості, твердості, розмазування та тремтіння одночасно.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum velocity set for all settings in this brush.</source>
-        <translation type="unfinished">Максимальна швидкість, встановлена для всіх налаштувань цього пензля.</translation>
+        <translation>Максимальна швидкість, встановлена для всіх налаштувань цього пензля.</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Set the maximum distance for Size, Opacity, Hardness, Smudging and Jitter at once.</source>
-        <translation type="unfinished">Встановіть максимальну відстань для розміру, непрозорості, жорсткості, розмазування та тремтіння одночасно.</translation>
+        <translation>Встановіть максимальну відстань для розміру, непрозорості, жорсткості, розмазування та тремтіння одночасно.</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Maximum distance set for all settings in this brush.</source>
-        <translation type="unfinished">Максимальна відстань, встановлена для всіх налаштувань цього пензля.</translation>
+        <translation>Максимальна відстань, встановлена для всіх налаштувань цього пензля.</translation>
     </message>
     <message>
         <location line="+89"/>
@@ -7706,7 +7708,7 @@ Values above 0.5 may not be noticeable.</source>
     <message>
         <location line="+25"/>
         <source>(redirected from %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>(перенаправлено з %1)</translation>
     </message>
     <message>
         <location line="+139"/>

--- a/src/drawdance/libengine/dpengine/pixels.c
+++ b/src/drawdance/libengine/dpengine/pixels.c
@@ -835,18 +835,18 @@ void DP_pixels15_to_8_tile(DP_Pixel8 *dst, const DP_Pixel15 *src)
 {
     DP_Pixel8 *aligned_dst = DP_ASSUME_SIMD_ALIGNED(dst);
     const DP_Pixel15 *aligned_src = DP_ASSUME_SIMD_ALIGNED(src);
-    switch (DP_cpu_support) {
 #ifdef DP_CPU_X64
-    case DP_CPU_SUPPORT_AVX2:
+    DP_CpuSupport cpu_support = DP_cpu_support;
+    if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
         pixels15_to_8_avx2(aligned_dst, aligned_src);
-        break;
-    case DP_CPU_SUPPORT_SSE42:
+    }
+    else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
         pixels15_to_8_sse42(aligned_dst, aligned_src);
-        break;
+    }
+    else
 #endif
-    default:
+    {
         DP_pixels15_to_8(aligned_dst, aligned_src, DP_TILE_LENGTH);
-        break;
     }
 }
 
@@ -3568,18 +3568,18 @@ static DP_Spectral rgb_to_spectral(BGRf bgr)
     float g = srgb_to_linear(bgr.g) * WGM_OFFSET + WGM_EPSILON;
     float r = srgb_to_linear(bgr.r) * WGM_OFFSET + WGM_EPSILON;
     DP_Spectral out;
-    switch (DP_cpu_support) {
 #ifdef DP_CPU_X64
-    case DP_CPU_SUPPORT_AVX2:
+    DP_CpuSupport cpu_support = DP_cpu_support;
+    if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
         rgb_to_spectral_avx2(b, g, r, out.channels);
-        break;
-    case DP_CPU_SUPPORT_SSE42:
+    }
+    else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
         rgb_to_spectral_sse42(b, g, r, out.channels);
-        break;
+    }
+    else
 #endif
-    default:
+    {
         rgb_to_spectral_scalar(b, g, r, out.channels);
-        break;
     }
     return out;
 }
@@ -4162,10 +4162,11 @@ static void blend_mask_normal(DP_Pixel15 *dst, DP_UPixel15 src,
                               int mask_skip, int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4176,7 +4177,7 @@ static void blend_mask_normal(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -4210,10 +4211,11 @@ static void blend_mask_normal_and_eraser(DP_Pixel15 *dst, DP_UPixel15 src,
                                          int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4225,7 +4227,7 @@ static void blend_mask_normal_and_eraser(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -4630,10 +4632,11 @@ static void blend_mask_recolor(DP_Pixel15 *dst, DP_UPixel15 src,
                                int h, int mask_skip, int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4644,7 +4647,7 @@ static void blend_mask_recolor(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -4677,10 +4680,11 @@ static void blend_mask_oklab_normal(DP_Pixel15 *dst, DP_UPixel15 src,
                                     int h, int mask_skip, int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4692,7 +4696,7 @@ static void blend_mask_oklab_normal(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -4726,10 +4730,11 @@ static void blend_mask_oklab_recolor(DP_Pixel15 *dst, DP_UPixel15 src,
                                      int h, int mask_skip, int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4741,7 +4746,7 @@ static void blend_mask_oklab_recolor(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -4776,10 +4781,11 @@ static void blend_mask_oklab_normal_and_eraser(DP_Pixel15 *dst, DP_UPixel15 src,
                                                int mask_skip, int base_skip)
 {
 #ifdef DP_CPU_X64
+    DP_CpuSupport cpu_support = DP_cpu_support;
     for (int y = 0; y < h; ++y) {
         int remaining = w;
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_AVX2) {
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             int remaining_after_avx_width = remaining % 8;
             int avx_width = remaining - remaining_after_avx_width;
 
@@ -4791,7 +4797,7 @@ static void blend_mask_oklab_normal_and_eraser(DP_Pixel15 *dst, DP_UPixel15 src,
             mask += avx_width;
         }
 
-        if (DP_cpu_support >= DP_CPU_SUPPORT_SSE42) {
+        if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             int remaining_after_sse_width = remaining % 4;
             int sse_width = remaining - remaining_after_sse_width;
 
@@ -6107,66 +6113,65 @@ void DP_blend_tile(DP_Pixel15 *DP_RESTRICT dst,
 #ifdef DP_CPU_X64
     switch (blend_mode) {
     // Alpha-affecting blend modes.
-    case DP_BLEND_MODE_NORMAL:
-        switch (DP_cpu_support) {
-        case DP_CPU_SUPPORT_AVX2:
+    case DP_BLEND_MODE_NORMAL: {
+        DP_CpuSupport cpu_support = DP_cpu_support;
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             blend_tile_normal_avx2(aligned_dst, aligned_src, opacity);
             return;
-        case DP_CPU_SUPPORT_SSE42:
+        }
+        else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             blend_tile_normal_sse42(aligned_dst, aligned_src, opacity);
             return;
-        default:
-            break;
         }
         break;
-    case DP_BLEND_MODE_RECOLOR:
-        switch (DP_cpu_support) {
-        case DP_CPU_SUPPORT_AVX2:
+    }
+    case DP_BLEND_MODE_RECOLOR: {
+        DP_CpuSupport cpu_support = DP_cpu_support;
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             blend_tile_recolor_avx2(aligned_dst, aligned_src, opacity);
             return;
-        case DP_CPU_SUPPORT_SSE42:
+        }
+        else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             blend_tile_recolor_sse42(aligned_dst, aligned_src, opacity);
-            return;
-        default:
-            break;
         }
         break;
-    case DP_BLEND_MODE_BEHIND:
-        switch (DP_cpu_support) {
-        case DP_CPU_SUPPORT_AVX2:
+    }
+    case DP_BLEND_MODE_BEHIND: {
+        DP_CpuSupport cpu_support = DP_cpu_support;
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             blend_tile_behind_avx2(aligned_dst, aligned_src, opacity);
             return;
-        case DP_CPU_SUPPORT_SSE42:
+        }
+        else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             blend_tile_behind_sse42(aligned_dst, aligned_src, opacity);
             return;
-        default:
-            break;
         }
         break;
-    case DP_BLEND_MODE_OKLAB_NORMAL:
-        switch (DP_cpu_support) {
-        case DP_CPU_SUPPORT_AVX2:
+    }
+    case DP_BLEND_MODE_OKLAB_NORMAL: {
+        DP_CpuSupport cpu_support = DP_cpu_support;
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             blend_tile_oklab_normal_avx2(aligned_dst, aligned_src, opacity);
             return;
-        case DP_CPU_SUPPORT_SSE42:
+        }
+        else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             blend_tile_oklab_normal_sse42(aligned_dst, aligned_src, opacity);
             return;
-        default:
-            break;
         }
         break;
-    case DP_BLEND_MODE_OKLAB_RECOLOR:
-        switch (DP_cpu_support) {
-        case DP_CPU_SUPPORT_AVX2:
+    }
+    case DP_BLEND_MODE_OKLAB_RECOLOR: {
+        DP_CpuSupport cpu_support = DP_cpu_support;
+        if (cpu_support >= DP_CPU_SUPPORT_AVX2) {
             blend_tile_oklab_recolor_avx2(aligned_dst, aligned_src, opacity);
             return;
-        case DP_CPU_SUPPORT_SSE42:
+        }
+        else if (cpu_support >= DP_CPU_SUPPORT_SSE42) {
             blend_tile_oklab_recolor_sse42(aligned_dst, aligned_src, opacity);
             return;
-        default:
-            break;
         }
         break;
+    }
     default:
         break;
     }

--- a/src/drawdance/libimpex/CMakeLists.txt
+++ b/src/drawdance/libimpex/CMakeLists.txt
@@ -100,4 +100,8 @@ if(BENCHMARKS)
     dp_add_executable(bench_multidab)
     dp_target_sources(bench_multidab bench/bench_multidab.c)
     target_link_libraries(bench_multidab PUBLIC dpimpex)
+
+    dp_add_executable(bench_flatten)
+    dp_target_sources(bench_flatten bench/bench_flatten.c)
+    target_link_libraries(bench_flatten PUBLIC dpimpex)
 endif()

--- a/src/drawdance/libimpex/bench/bench_flatten.c
+++ b/src/drawdance/libimpex/bench/bench_flatten.c
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <dpcommon/common.h>
+#include <dpcommon/conversions.h>
+#include <dpcommon/cpu.h>
+#include <dpcommon/output.h>
+#include <dpengine/canvas_state.h>
+#include <dpengine/image.h>
+#include <dpengine/layer_content.h>
+#include <dpengine/layer_list.h>
+#include <dpengine/layer_props.h>
+#include <dpengine/layer_props_list.h>
+#include <dpimpex/image_impex.h>
+#include <dpmsg/blend_mode.h>
+#include <math.h>
+#include <rng-double.h>
+#include <stdio.h>
+
+static bool parse_args(int argc, char **argv, int *out_width, int *out_height,
+                       int *out_iterations, long *out_seed, int *out_mode,
+                       const char **out_path)
+{
+    int min_args = 6;
+    if (argc != min_args && argc != min_args + 1) {
+        fprintf(stderr, "Expected %d or %d arguments, but got %d\n",
+                min_args - 1, min_args, argc - 1);
+        return false;
+    }
+
+    int width = atoi(argv[1]);
+    if (!DP_canvas_state_in_max_dimension_bound(width)) {
+        fputs("Width out of bounds\n", stderr);
+        return false;
+    }
+
+    int height = atoi(argv[2]);
+    if (!DP_canvas_state_in_max_dimension_bound(height)) {
+        fputs("Height out of bounds\n", stderr);
+        return false;
+    }
+
+    if (!DP_canvas_state_in_max_pixels_bound(width, height)) {
+        fputs("Dimensions out of bounds\n", stderr);
+        return false;
+    }
+
+    int iterations = atoi(argv[3]);
+    long seed = atol(argv[4]);
+
+    DP_BlendMode mode = DP_blend_mode_by_ora_name(argv[5], DP_BLEND_MODE_COUNT);
+    if (mode == DP_BLEND_MODE_COUNT) {
+        fprintf(stderr, "Unknown blend mode '%s'\n", argv[5]);
+        return false;
+    }
+
+    *out_width = width;
+    *out_height = height;
+    *out_iterations = iterations;
+    *out_seed = seed;
+    *out_mode = (int)mode;
+    *out_path = argc < 7 ? NULL : argv[6];
+    return true;
+}
+
+static double get_random(RngDouble *rng)
+{
+    return fabs(fmod(rng_double_next(rng), 1.0));
+}
+
+static DP_TransientLayerProps *
+generate_layer_props(int layer_id, int blend_mode, uint16_t opacity)
+{
+    DP_TransientLayerProps *tlp =
+        DP_transient_layer_props_new_init(layer_id, false);
+    DP_transient_layer_props_blend_mode_set(tlp, blend_mode);
+    DP_transient_layer_props_opacity_set(tlp, opacity);
+    return tlp;
+}
+
+static DP_TransientLayerContent *generate_layer_content(RngDouble *rng,
+                                                        int width, int height)
+{
+    DP_TransientLayerContent *tlc =
+        DP_transient_layer_content_new_init(width, height, NULL);
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            double a = get_random(rng);
+            DP_Pixel15 pixel = {
+                DP_channel_float_to_15(DP_double_to_float(get_random(rng) * a)),
+                DP_channel_float_to_15(DP_double_to_float(get_random(rng) * a)),
+                DP_channel_float_to_15(DP_double_to_float(get_random(rng) * a)),
+                DP_channel_float_to_15(DP_double_to_float(a)),
+            };
+            DP_transient_layer_content_pixel_at_set(tlc, 0, x, y, pixel);
+        }
+    }
+
+    return tlc;
+}
+
+static DP_CanvasState *generate_canvas(RngDouble *rng, int width, int height,
+                                       int mode)
+{
+    DP_TransientCanvasState *tcs = DP_transient_canvas_state_new_init();
+    DP_transient_canvas_state_width_set(tcs, width);
+    DP_transient_canvas_state_height_set(tcs, height);
+
+    DP_TransientLayerList *tll =
+        DP_transient_canvas_state_transient_layers(tcs, 2);
+    DP_transient_layer_list_set_transient_content_noinc(
+        tll, generate_layer_content(rng, width, height), 0);
+    DP_transient_layer_list_set_transient_content_noinc(
+        tll, generate_layer_content(rng, width, height), 1);
+
+    DP_TransientLayerPropsList *tlpl =
+        DP_transient_canvas_state_transient_layer_props(tcs, 2);
+    DP_transient_layer_props_list_set_transient_noinc(
+        tlpl,
+        generate_layer_props(
+            1, DP_BLEND_MODE_NORMAL,
+            DP_channel_float_to_15(DP_double_to_float(get_random(rng)))),
+        0);
+    DP_transient_layer_props_list_set_transient_noinc(
+        tlpl,
+        generate_layer_props(
+            2, mode,
+            DP_channel_float_to_15(DP_double_to_float(get_random(rng)))),
+        1);
+
+    return DP_transient_canvas_state_persist(tcs);
+}
+
+int main(int argc, char **argv)
+{
+    DP_cpu_support_init();
+    DP_image_impex_init();
+
+    int width, height, iterations, mode;
+    long seed;
+    const char *path;
+    if (!parse_args(argc, argv, &width, &height, &iterations, &seed, &mode,
+                    &path)) {
+        fprintf(stderr,
+                "Usage: %s WIDTH HEIGHT ITERATIONS SEED MODE [PATH_TO_PNG]\n",
+                argc > 0 && argv[0] ? argv[0] : "bench_flatten");
+        return 2;
+    }
+
+    RngDouble *rng = rng_double_new(seed);
+    DP_CanvasState *cs = generate_canvas(rng, width, height, mode);
+    rng_double_free(rng);
+
+    for (int i = 0; i < iterations; ++i) {
+        DP_TransientLayerContent *tlc =
+            DP_canvas_state_to_flat_layer(cs, DP_FLAT_IMAGE_RENDER_FLAGS, NULL);
+        if (tlc) {
+            DP_transient_layer_content_decref(tlc);
+        }
+    }
+
+    if (path) {
+        DP_Output *out = DP_file_output_new_from_path(path);
+        if (!out) {
+            DP_canvas_state_decref(cs);
+            fprintf(stderr, "%s\n", DP_error());
+            return 1;
+        }
+
+        DP_Image *img = DP_canvas_state_to_flat_image(
+            cs, DP_FLAT_IMAGE_RENDER_FLAGS, NULL, NULL);
+        DP_canvas_state_decref(cs);
+        if (!img) {
+            fprintf(stderr, "%s\n", DP_error());
+            DP_output_free_discard(out);
+            return 1;
+        }
+
+        if (!DP_image_write_png(img, out)) {
+            fprintf(stderr, "%s\n", DP_error());
+            DP_output_free_discard(out);
+            return 1;
+        }
+
+        if (!DP_output_free(out)) {
+            fprintf(stderr, "%s\n", DP_error());
+            return 1;
+        }
+
+        return 0;
+    }
+    else {
+        DP_canvas_state_decref(cs);
+        return 0;
+    }
+}

--- a/src/libclient/i18n/libclient_de_DE.ts
+++ b/src/libclient/i18n/libclient_de_DE.ts
@@ -1876,7 +1876,7 @@ Wählen Sie stattdessen eine normale Ebene.</translation>
     <message>
         <location line="-1066"/>
         <source>Got redirected to a server that doesn&apos;t accept redirects: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Wurde zu einem Server weitergeleitet, der keine Weiterleitungen akzeptiert: %1</translation>
     </message>
     <message>
         <location line="+49"/>
@@ -1911,12 +1911,12 @@ Wählen Sie stattdessen eine normale Ebene.</translation>
     <message>
         <location line="+20"/>
         <source>Incompatible redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Inkompatible Weiterleitung</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Circular redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Zirkuläre Weiterleitung</translation>
     </message>
     <message>
         <location line="+7"/>

--- a/src/libclient/i18n/libclient_de_DE.ts
+++ b/src/libclient/i18n/libclient_de_DE.ts
@@ -1921,7 +1921,7 @@ Wählen Sie stattdessen eine normale Ebene.</translation>
     <message>
         <location line="+7"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation>Zu viele Weiterleitungen</translation>
     </message>
     <message>
         <location line="+159"/>

--- a/src/libclient/i18n/libclient_es_CO.ts
+++ b/src/libclient/i18n/libclient_es_CO.ts
@@ -1640,7 +1640,7 @@ En su lugar, selecciona una capa regular.</translation>
         <location line="+5"/>
         <source>Session terminated by moderator (%1).</source>
         <extracomment>%1 is the name of the moderator.</extracomment>
-        <translation>Sesión finalizada por un moderador (%1)</translation>
+        <translation>Sesión finalizada por un moderador (%1).</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/libclient/i18n/libclient_es_CO.ts
+++ b/src/libclient/i18n/libclient_es_CO.ts
@@ -174,7 +174,7 @@
     <message>
         <location line="+1"/>
         <source>Checking for updates…</source>
-        <translation type="unfinished">Buscando actualizaciones…</translation>
+        <translation>Buscando actualizaciones…</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -1028,7 +1028,7 @@ En su lugar, selecciona una capa regular.</translation>
     <message>
         <location line="+18"/>
         <source>Pin Light</source>
-        <translation type="unfinished">Luz de alfiler</translation>
+        <translation>Fijar Luz</translation>
     </message>
     <message>
         <location line="+18"/>
@@ -1769,7 +1769,7 @@ En su lugar, selecciona una capa regular.</translation>
     <message>
         <location line="+50"/>
         <source>Got redirected to a server that doesn&apos;t accept redirects: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuiste redirigido a un servidor que no acepta redirecciones: %1</translation>
     </message>
     <message>
         <location line="+49"/>
@@ -1799,17 +1799,17 @@ En su lugar, selecciona una capa regular.</translation>
     <message>
         <location line="+20"/>
         <source>Incompatible redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Redirección incompatible</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Circular redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Redirección circular</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation>Demasiadas redirecciones</translation>
     </message>
     <message>
         <location line="+57"/>
@@ -2020,7 +2020,7 @@ En su lugar, selecciona una capa regular.</translation>
     <message>
         <location line="+4"/>
         <source>Unlisted</source>
-        <translation type="unfinished">Desenlistado</translation>
+        <translation>Desenlistado</translation>
     </message>
     <message>
         <location line="+2"/>

--- a/src/libclient/i18n/libclient_uk_UA.ts
+++ b/src/libclient/i18n/libclient_uk_UA.ts
@@ -1772,7 +1772,7 @@ Select a regular layer instead.</source>
     <message>
         <location line="+50"/>
         <source>Got redirected to a server that doesn&apos;t accept redirects: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Перенаправлено на сервер, який не приймає перенаправлення: %1</translation>
     </message>
     <message>
         <location line="+49"/>
@@ -1802,17 +1802,17 @@ Select a regular layer instead.</source>
     <message>
         <location line="+20"/>
         <source>Incompatible redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Несумісне перенаправлення</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Circular redirect</source>
-        <translation type="unfinished"></translation>
+        <translation>Циркулярне перенаправлення</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>Too many redirects</source>
-        <translation type="unfinished"></translation>
+        <translation>Забагато переадресацій</translation>
     </message>
     <message>
         <location line="+57"/>


### PR DESCRIPTION
Rejiggerment of #1503:

* Swaps red and blue channels in SSE 4.2, since that was the wrong way round.
* Replaces the unaligned pixel blending functions with aligned tile blending functions because that covers most cases and gets rid of that weird issue where the lasso fill stops filling.
* Implements a SIMD version of OKLAB tile blending with alpha preserve… and also Normal tile blending with alpha preserve (Recolor) because apparently we didn't have that before.
* Uses a different means of fastpow on MSVC because vfastpow uses GCC extensions. I know how to work around some of them, but no clue how to e.g. implement `&` when there doesn't seem to be any `_mm_and_epi32` around.
* Makes CPU support checks work the same everywhere, previously it missed that AVX CPUs also support SSE 4.2 in some cases.