### PR TITLE
feature/brush outline antialiasing

### DIFF
--- a/src/desktop/scene/outlineitem.cpp
+++ b/src/desktop/scene/outlineitem.cpp
@@ -52,16 +52,18 @@ void OutlineItem::paint(
 {
 	if(m_actuallyVisible) {
 		painter->save();
+		painter->setRenderHint(QPainter::Antialiasing, true);
 
 		QPen pen;
 		const QPaintEngine *pe = painter->paintEngine();
-		if(pe->hasFeature(QPaintEngine::RasterOpModes)) {
-			pen.setColor(QColor(96, 191, 96));
-			painter->setCompositionMode(
-				QPainter::RasterOp_SourceXorDestination);
-		} else if(pe->hasFeature(QPaintEngine::BlendModes)) {
+		if(pe->hasFeature(QPaintEngine::BlendModes)) {
 			pen.setColor(QColor(0, 255, 0));
 			painter->setCompositionMode(QPainter::CompositionMode_Difference);
+		} else if(pe->hasFeature(QPaintEngine::RasterOpModes)) {
+			pen.setColor(QColor(96, 191, 96));
+			painter->setRenderHint(QPainter::Antialiasing, false);
+			painter->setCompositionMode(
+				QPainter::RasterOp_SourceXorDestination);
 		} else {
 			pen.setColor(QColor(191, 96, 191));
 		}


### PR DESCRIPTION
Adds antialiasing to the software brush outline.

I'm trying to also make it work with the hardware brush outline, but it turns out there is no GL blend mode and blend equation combination that would do a subtract/difference/xor effect AND allow alpha blending at the same time. There are two things I can think of:
1. Do it in the outline shader, but I would need the current rendered viewport in a texture to be able to sample, and I'd need to use an FBO to do that. Question is, does the GLES we are using support FBO creation?
2. Reuse `OutlineItem`, but make another transparent `GraphicsView` overlay on top of the OpenGL widget, and have the `OutlineItem` paint inside of that, and hopefully the blending just magically works (it probably wont). I tried using `OutlineItem` without doing that by forcing its creation from `ViewWrapper` (and hooking up the transform update in `GlCanvas`), but the `PaintEngine` it receives will throw an error about unsupported composition modes, which makes sense if the underlying `PaintEngine` is now OpenGL in this context.

Software brush outline with AA:
<img width="1918" height="1051" alt="image" src="https://github.com/user-attachments/assets/4c03f70f-d300-490f-875c-768f0e372c17" />

Hardware brush outline with AA, but no color blending:
<img width="1918" height="1051" alt="image" src="https://github.com/user-attachments/assets/17b27ff3-cfe0-4105-9424-09170e82b6c8" />

Changes to `GlCanvas` to add AA, but no blending (not committed to this branch yet):
```diff
diff --git a/src/desktop/view/glcanvas.cpp b/src/desktop/view/glcanvas.cpp
index 4fb0ee79a..043801c53 100644
--- a/src/desktop/view/glcanvas.cpp
+++ b/src/desktop/view/glcanvas.cpp
@@ -413,11 +413,6 @@ uniform vec2 u_pos;
 uniform vec2 u_translation;
 uniform mat3 u_transform;
 DP_VERTEX_IN mediump vec2 v_pos;
-#ifdef DP_HAVE_HIGHP
-DP_VERTEX_OUT highp vec2 f_pos;
-#else
-DP_VERTEX_OUT vec2 f_pos;
-#endif
 
 void main()
 {
@@ -426,7 +421,6 @@ void main()
        float x = 2.0 * pos.x / u_view.x;
        float y = -2.0 * pos.y / u_view.y;
        gl_Position = vec4(x, y, 0.0, 1.0);
-       f_pos = v_pos;
 }
        )""";
 
@@ -434,15 +428,21 @@ void main()
 precision mediump float;
 
 #ifdef DP_HAVE_HIGHP
+uniform highp vec2 u_view;
+uniform highp vec2 u_pos;
+uniform highp vec2 u_translation;
+uniform highp mat3 u_transform;
 uniform highp float u_size;
 uniform highp float u_width;
 uniform highp float u_shape;
-DP_FRAGMENT_IN highp vec2 f_pos;
 #else
+uniform vec2 u_view;
+uniform vec2 u_pos;
+uniform vec2 u_translation;
+uniform mat3 u_transform;
 uniform float u_size;
 uniform float u_width;
 uniform float u_shape;
-DP_FRAGMENT_IN vec2 f_pos;
 #endif
 #ifdef DP_FRAGMENT_OUT
 DP_FRAGMENT_OUT vec4 DP_FRAG_COLOR;
@@ -452,17 +452,33 @@ void main()
 {
 #ifdef DP_HAVE_HIGHP
        highp float distance;
+       highp vec2 pos;
+       highp vec2 frag_pos;
+       highp float alpha;
 #else
        float distance;
+       vec2 pos;
+       vec2 frag_pos;
+       float alpha;
 #endif
+       pos = vec2(1, -1)
+               * floor((u_transform * vec3(u_pos, 0.0)).xy + u_translation + 0.5);
+       frag_pos = gl_FragCoord.xy - (u_view * 0.5) - pos;
+       alpha = 0;
        distance = u_shape < 0.5
-               ? abs(length(f_pos) - u_size + u_width) // Circle
-               : abs(max(abs(f_pos.x), abs(f_pos.y)) - u_size + u_width); // Square
-       if(distance <= u_width * 0.5) {
-               DP_FRAG_COLOR = vec4(0.5, 1.0, 0.5, 1.0);
-       } else {
+               ? abs(length(frag_pos) - u_size + u_width) // Circle
+               : abs(max(abs(frag_pos.x), abs(frag_pos.y)) - u_size + u_width); // Square
+       alpha = clamp(max(1, u_width) - distance, 0, 1);
+       if (alpha == 0) {
                discard;
        }
+       else
+       {
+               DP_FRAG_COLOR = vec4(0.5, 1.0, 0.5, alpha);
+               // Dst blending, something like:
+               // vec3 canvas_color = DP_TEXTURE2D(u_viewport, frag_pos / u_view).rgb;
+               // DP_FRAG_COLOR = vec4(abs(canvas_color - vec3(0.5, 1.0, 0.5)), alpha);
+       }
 }
        )""";
 
@@ -908,8 +924,7 @@ void main()
        {
                DP_PERF_SCOPE("paint_gl:outline");
                f->glEnable(GL_BLEND);
-               f->glBlendFuncSeparate(GL_ONE, GL_SRC_COLOR, GL_ONE, GL_ONE);
-               f->glBlendEquationSeparate(GL_FUNC_SUBTRACT, GL_FUNC_ADD);
+               f->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
                f->glUseProgram(outlineShader.program);
 
@@ -922,9 +937,9 @@ void main()
                        outlineShader.translationLocation, translationX, translationY);
                f->glUniformMatrix3fv(
                        outlineShader.transformLocation, 1, GL_FALSE, transform);
-               int outlineSize = controller->outlineSize();
+               int outlineSize = controller->outlineSize() * controller->zoom();
                qreal outlineWidth =
-                       controller->outlineWidth() / controller->zoom() * dpr;
+                       controller->outlineWidth() * dpr;
                f->glUniform1f(
                        outlineShader.sizeLocation, outlineSize * 0.5f + outlineWidth);
                f->glUniform1f(outlineShader.widthLocation, outlineWidth);
@@ -941,7 +956,9 @@ void main()
 
                f->glBindBuffer(
                        GL_ARRAY_BUFFER, buffers[Private::OUTLINE_VERTEX_BUFFER_INDEX]);
-               refreshOutlineVertices(f, outlineSize, outlineWidth);
+               const int antialias_padding = 4;
+               refreshOutlineVertices(f, controller->outlineSize(),
+                       outlineWidth / controller->zoom() + antialias_padding);
                f->glVertexAttribPointer(0, 2, GL_FLOAT, false, 0, nullptr);
 
                f->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
```