### PR TITLE
Haiku build fixes

### DIFF
--- a/src/desktop/bundled/miniaudio/CMakeLists.txt
+++ b/src/desktop/bundled/miniaudio/CMakeLists.txt
@@ -15,6 +15,6 @@ target_compile_definitions(miniaudio PUBLIC
 # Some platforms need extra flags.
 if(APPLE)
     target_link_options(miniaudio PUBLIC -lpthread -lm)
-elseif(UNIX AND NOT ANDROID AND NOT EMSCRIPTEN)
+elseif(UNIX AND NOT ANDROID AND NOT HAIKU AND NOT EMSCRIPTEN)
     target_link_libraries(miniaudio PUBLIC -latomic -ldl -lpthread -lm)
 endif()

--- a/src/drawdance/libimpex/dpimpex/save.c
+++ b/src/drawdance/libimpex/dpimpex/save.c
@@ -1124,7 +1124,7 @@ DP_SaveResult DP_save(DP_CanvasState *cs, DP_DrawContext *dc,
 #    define PREFERRED_PATH_SEPARATOR "\\"
 #    define POSSIBLE_PATH_SEPARATORS "\\/"
 #elif defined(__EMSCRIPTEN__) || defined(__APPLE__) || defined(__linux__) \
-    || defined(__Haiku__)
+    || defined(__HAIKU__)
 #    define PREFERRED_PATH_SEPARATOR "/"
 #    define POSSIBLE_PATH_SEPARATORS "/"
 #else


### PR DESCRIPTION
Define Haiku as __HAIKU__ and Haiku doesn't use -ldl