### PR TITLE
Windows thumbnail shell extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,11 @@ if(TOOLS)
 	add_subdirectory(src/tools)
 endif()
 
+if(WIN_SHELL_EXT)
+	message(STATUS "Adding win-shell-ext")
+	add_subdirectory(src/win-shell-ext)
+endif()
+
 if(CARGO_COMMAND)
 	add_custom_target(clippy
 		COMMAND "${CARGO_COMMAND}" clippy --

--- a/cmake/DrawpileOptions.cmake
+++ b/cmake/DrawpileOptions.cmake
@@ -53,7 +53,7 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
 	add_feature_info("Benchmarks (BENCHMARKS)" BENCHMARKS "")
 
 	cmake_dependent_option(
-		WIN_SHELL_EXT "Build Windows shell extension for .dpcs thumbnail provider"
+		WIN_SHELL_EXT "Build Windows shell extension for .dpcs/.dppr thumbnail provider"
 		ON "WIN32;CLIENT" OFF)
 	add_feature_info("Windows shell extension (WIN_SHELL_EXT)" WIN_SHELL_EXT "")
 else()

--- a/cmake/DrawpileOptions.cmake
+++ b/cmake/DrawpileOptions.cmake
@@ -51,6 +51,11 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
 
 	option(BENCHMARKS "Build benchmarks" OFF)
 	add_feature_info("Benchmarks (BENCHMARKS)" BENCHMARKS "")
+
+	cmake_dependent_option(
+		WIN_SHELL_EXT "Build Windows shell extension for .dpcs thumbnail provider"
+		ON "WIN32;CLIENT" OFF)
+	add_feature_info("Windows shell extension (WIN_SHELL_EXT)" WIN_SHELL_EXT "")
 else()
 	# CMake allows unexposed options to be enabled
 	set(SERVER OFF CACHE BOOL "" FORCE)

--- a/cmake/DrawpilePackaging.cmake
+++ b/cmake/DrawpilePackaging.cmake
@@ -75,6 +75,9 @@ elseif(WIN32)
 		configure_file("pkg/installer-${CPACK_WIX_ARCHITECTURE}.wix.in" pkg/installer.wix)
 
 		set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_BINARY_DIR}/pkg/installer.wix")
+		if(WIN_SHELL_EXT)
+			list(APPEND CPACK_WIX_PATCH_FILE "${PROJECT_SOURCE_DIR}/pkg/installer-shell-ext.wxs")
+		endif()
 
 		set(CPACK_WIX_EXTRA_SOURCES "${PROJECT_SOURCE_DIR}/pkg/installer-nolicense.wxs")
 		set(CPACK_WIX_UI_REF "WixUI_InstallDir_NoLicense")

--- a/pkg/installer-shell-ext.wxs
+++ b/pkg/installer-shell-ext.wxs
@@ -1,0 +1,16 @@
+<CPackWiXPatch>
+	<CPackWiXFragment Id="CM_CP_drawpile_shell_ext.dll">
+		<RegistryValue Root="HKLM"
+			Key="Software\Classes\CLSID\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}"
+			Value="Drawpile Thumbnail Provider" Type="string"/>
+		<RegistryValue Root="HKLM"
+			Key="Software\Classes\CLSID\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}\InprocServer32"
+			Value="[INSTALL_ROOT]drawpile_shell_ext.dll" Type="string"/>
+		<RegistryValue Root="HKLM"
+			Key="Software\Classes\CLSID\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}\InprocServer32"
+			Name="ThreadingModel" Value="Apartment" Type="string"/>
+		<RegistryValue Root="HKLM"
+			Key="Software\Classes\.dpcs\ShellEx\{E357FCCD-A995-4576-B01F-234630154E96}"
+			Value="{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}" Type="string"/>
+	</CPackWiXFragment>
+</CPackWiXPatch>

--- a/pkg/installer-shell-ext.wxs
+++ b/pkg/installer-shell-ext.wxs
@@ -11,6 +11,9 @@
 			Name="ThreadingModel" Value="Apartment" Type="string"/>
 		<RegistryValue Root="HKLM"
 			Key="Software\Classes\.dpcs\ShellEx\{E357FCCD-A995-4576-B01F-234630154E96}"
+			Value="{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}" Type="string"/>		
+		<RegistryValue Root="HKLM"
+			Key="Software\Classes\.dppr\ShellEx\{E357FCCD-A995-4576-B01F-234630154E96}"
 			Value="{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}" Type="string"/>
 	</CPackWiXFragment>
 </CPackWiXPatch>

--- a/src/win-shell-ext/CMakeLists.txt
+++ b/src/win-shell-ext/CMakeLists.txt
@@ -7,7 +7,6 @@ add_compile_definitions(
     NOMINMAX
 )
 
-find_package(SQLite3 REQUIRED)
 add_library(drawpile_shell_ext SHARED
 	main.cpp
 	ThumbnailProvider.cpp
@@ -26,6 +25,6 @@ dp_sign_executable(drawpile_shell_ext)
 dp_install_executables(TARGETS drawpile_shell_ext)
 
 if(TESTS)
-	add_executable(test_drawpile_shell_ext src/test_main.cpp)
+	add_executable(test_drawpile_shell_ext test_main.cpp)
 	target_link_libraries(test_drawpile_shell_ext PRIVATE shlwapi.lib)
 endif()

--- a/src/win-shell-ext/CMakeLists.txt
+++ b/src/win-shell-ext/CMakeLists.txt
@@ -23,6 +23,7 @@ if(NOT MSVC)
     target_compile_options(drawpile_shell_ext PRIVATE -Wno-language-extension-token -Wno-c++98-compat-extra-semi)
 endif()
 dp_sign_executable(drawpile_shell_ext)
+dp_install_executables(TARGETS drawpile_shell_ext)
 
 if(TESTS)
 	add_executable(test_drawpile_shell_ext src/test_main.cpp)

--- a/src/win-shell-ext/CMakeLists.txt
+++ b/src/win-shell-ext/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(drawpile_shell_ext SHARED
 	exports.def
 )
 target_link_libraries(drawpile_shell_ext PRIVATE
-	SQLite3::SQLite3
+	bundled_sqlite3
 	runtimeobject.lib
 )
 if(NOT MSVC) 
@@ -27,8 +27,5 @@ dp_install_executables(TARGETS drawpile_shell_ext)
 
 if(TESTS)
 	add_executable(test_drawpile_shell_ext src/test_main.cpp)
-	target_link_libraries(test_drawpile_shell_ext PRIVATE
-		SQLite3::SQLite3
-		shlwapi.lib
-	)
+	target_link_libraries(test_drawpile_shell_ext PRIVATE shlwapi.lib)
 endif()

--- a/src/win-shell-ext/CMakeLists.txt
+++ b/src/win-shell-ext/CMakeLists.txt
@@ -1,0 +1,33 @@
+if(NOT WIN32)
+    message(FATAL_ERROR "Windows shell extension can only be built on windows")
+endif()
+
+add_compile_definitions(
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+)
+
+find_package(SQLite3 REQUIRED)
+add_library(drawpile_shell_ext SHARED
+	main.cpp
+	ThumbnailProvider.cpp
+	dpcs.cpp
+	exports.def
+)
+target_link_libraries(drawpile_shell_ext PRIVATE
+	SQLite3::SQLite3
+	runtimeobject.lib
+)
+if(NOT MSVC) 
+    # Needed for WRL
+    target_compile_options(drawpile_shell_ext PRIVATE -Wno-language-extension-token -Wno-c++98-compat-extra-semi)
+endif()
+dp_sign_executable(drawpile_shell_ext)
+
+if(TESTS)
+	add_executable(test_drawpile_shell_ext src/test_main.cpp)
+	target_link_libraries(test_drawpile_shell_ext PRIVATE
+		SQLite3::SQLite3
+		shlwapi.lib
+	)
+endif()

--- a/src/win-shell-ext/ThumbnailProvider.cpp
+++ b/src/win-shell-ext/ThumbnailProvider.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "ThumbnailProvider.h"
 #include "dpcs.h"
 #include <wrl/module.h>
@@ -44,7 +46,12 @@ HRESULT STDMETHODCALLTYPE ThumbnailProvider::GetThumbnail(
 		return hr;
 	}
 
-	sqlite3_close(db);
+	int rc = sqlite3_close(db);
+	if(rc != SQLITE_OK) {
+		fprintf(stderr, "Fail to close database: %s\n", sqlite3_errmsg(db));
+
+		return E_FAIL;
+	}
 
 	return S_OK;
 }

--- a/src/win-shell-ext/ThumbnailProvider.cpp
+++ b/src/win-shell-ext/ThumbnailProvider.cpp
@@ -1,0 +1,52 @@
+#include "ThumbnailProvider.h"
+#include "dpcs.h"
+#include <wrl/module.h>
+
+using namespace Microsoft::WRL;
+
+HRESULT STDMETHODCALLTYPE ThumbnailProvider::Initialize(IStream *pstream, DWORD)
+{
+	if(!pstream)
+		return E_INVALIDARG;
+	if(m_pStream)
+		return HRESULT_FROM_WIN32(ERROR_ALREADY_INITIALIZED);
+	m_pStream = pstream;
+
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE ThumbnailProvider::GetThumbnail(
+	UINT cx, HBITMAP *phbmp, WTS_ALPHATYPE *pdwAlpha)
+{
+	if(!phbmp || !pdwAlpha)
+		return E_POINTER;
+	*phbmp = nullptr;
+	*pdwAlpha = WTSAT_RGB;
+
+	HRESULT hr;
+
+	std::vector<unsigned char> dpcsBuf;
+	if(FAILED(hr = IStreamToBuffer(m_pStream.Get(), dpcsBuf)))
+		return hr;
+
+	sqlite3 *db;
+	if(FAILED(hr = OpenSqlite(dpcsBuf, &db)))
+		return hr;
+
+	std::vector<unsigned char> jpegBuf;
+	if(FAILED(hr = ExtractJPEG(db, jpegBuf))) {
+		sqlite3_close(db);
+		return hr;
+	}
+
+	if(FAILED(hr = JpegToHBitmap(jpegBuf.data(), jpegBuf.size(), cx, phbmp))) {
+		sqlite3_close(db);
+		return hr;
+	}
+
+	sqlite3_close(db);
+
+	return S_OK;
+}
+
+CoCreatableClass(ThumbnailProvider);

--- a/src/win-shell-ext/ThumbnailProvider.h
+++ b/src/win-shell-ext/ThumbnailProvider.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <propsys.h>
+#include <thumbcache.h>
+#include <windows.h>
+#include <wrl/implements.h>
+
+using namespace Microsoft::WRL;
+
+class __declspec(uuid("3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301"))
+ThumbnailProvider final : public RuntimeClass<
+							  RuntimeClassFlags<ClassicCom>,
+							  IInitializeWithStream, IThumbnailProvider> {
+	ComPtr<IStream> m_pStream;
+
+public:
+	IFACEMETHOD(Initialize)(IStream *pstream, DWORD grfMode) override;
+	IFACEMETHOD(GetThumbnail)(
+		UINT cx, HBITMAP *phbmp, WTS_ALPHATYPE *pdwAlpha) override;
+};

--- a/src/win-shell-ext/ThumbnailProvider.h
+++ b/src/win-shell-ext/ThumbnailProvider.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #pragma once
 #include <propsys.h>
 #include <thumbcache.h>

--- a/src/win-shell-ext/dpcs.cpp
+++ b/src/win-shell-ext/dpcs.cpp
@@ -1,0 +1,181 @@
+#include "dpcs.h"
+#include <algorithm>
+#include <cstdint>
+#include <intsafe.h>
+#include <wincodec.h>
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+
+HRESULT IStreamToBuffer(IStream *stream, std::vector<unsigned char> &out)
+{
+	HRESULT hr;
+
+	STATSTG stats;
+	if(FAILED(hr = stream->Stat(&stats, STATFLAG_NONAME)))
+		return hr;
+
+	out.resize(stats.cbSize.QuadPart);
+
+	ULONG bytesRead;
+	if(FAILED(
+		   hr = stream->Read(
+			   out.data(), static_cast<uint32_t>(out.size()), &bytesRead)))
+		return hr;
+
+	if(out.size() > bytesRead) {
+		out.resize(bytesRead);
+	}
+
+	return S_OK;
+}
+
+HRESULT OpenSqlite(std::vector<unsigned char> &databaseBuffer, sqlite3 **out)
+{
+	int rc;
+	rc = sqlite3_open(":memory:", out);
+	if(rc != SQLITE_OK) {
+		fprintf(stderr, "Cannot open database: %s\n", sqlite3_errmsg(*out));
+		sqlite3_close(*out);
+		return E_FAIL;
+	}
+
+	rc = sqlite3_deserialize(
+		*out, nullptr, databaseBuffer.data(), databaseBuffer.size(),
+		databaseBuffer.size(), SQLITE_DESERIALIZE_READONLY);
+	if(rc != SQLITE_OK) {
+		fprintf(
+			stderr, "Fail to deserialized database: %s\n",
+			sqlite3_errmsg(*out));
+		sqlite3_close(*out);
+		return E_FAIL;
+	}
+
+	return S_OK;
+}
+
+HRESULT ExtractJPEG(sqlite3 *db, std::vector<unsigned char> &out)
+{
+	sqlite3_stmt *stmt;
+	int rc;
+	rc = sqlite3_prepare_v2(
+		db, "SELECT thumbnail FROM snapshots ORDER BY taken_at DESC LIMIT 1",
+		-1, &stmt, nullptr);
+	if(rc != SQLITE_OK) {
+		fprintf(stderr, "Fail to query database: %s\n", sqlite3_errmsg(db));
+		return E_FAIL;
+	}
+	rc = sqlite3_step(stmt);
+	if(rc != SQLITE_ROW) {
+		fprintf(stderr, "Fail to query database: %s\n", sqlite3_errmsg(db));
+		sqlite3_finalize(stmt);
+		return E_FAIL;
+	}
+
+	const uint8_t *rowData =
+		static_cast<const uint8_t *>(sqlite3_column_blob(stmt, 0));
+	int rowSize = sqlite3_column_bytes(stmt, 0);
+
+	// Copy result to buffer
+	out.assign(rowData, rowData + rowSize);
+
+	// rowData is freed by sqlite3_finalize
+	sqlite3_finalize(stmt);
+
+	return S_OK;
+}
+
+HRESULT
+JpegToHBitmap(unsigned char *data, size_t size, uint32_t cx, HBITMAP *phbmp)
+{
+	if(!data || !size || !phbmp)
+		return E_INVALIDARG;
+	*phbmp = nullptr;
+
+	ComPtr<IWICImagingFactory> factory;
+	HRESULT hr = CoCreateInstance(
+		CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+		IID_PPV_ARGS(&factory));
+	if(FAILED(hr))
+		return hr;
+
+	ComPtr<IWICStream> wicStream;
+	if(FAILED(hr = factory->CreateStream(&wicStream)))
+		return hr;
+	// InitializeFromMemory takes non-const BYTE* but does not modify the buffer
+	if(FAILED(
+		   hr = wicStream->InitializeFromMemory(
+			   data, static_cast<int32_t>(size))))
+		return hr;
+
+	ComPtr<IWICBitmapDecoder> decoder;
+	if(FAILED(
+		   hr = factory->CreateDecoderFromStream(
+			   wicStream.Get(), nullptr, WICDecodeMetadataCacheOnLoad,
+			   &decoder)))
+		return hr;
+
+	ComPtr<IWICBitmapFrameDecode> frame;
+	if(FAILED(hr = decoder->GetFrame(0, &frame)))
+		return hr;
+
+	uint32_t srcW = 0, srcH = 0;
+	if(FAILED(hr = frame->GetSize(&srcW, &srcH)))
+		return hr;
+
+	// Scale to fit within cx×cx, maintaining aspect ratio
+	uint32_t outW, outH;
+	if(srcW >= srcH) {
+		outW = cx;
+		outH = std::max(1u, srcH * cx / srcW);
+	} else {
+		outH = cx;
+		outW = std::max(1u, srcW * cx / srcH);
+	}
+
+	ComPtr<IWICBitmapScaler> scaler;
+	if(FAILED(hr = factory->CreateBitmapScaler(&scaler)))
+		return hr;
+	if(FAILED(
+		   hr = scaler->Initialize(
+			   frame.Get(), outW, outH, WICBitmapInterpolationModeFant)))
+		return hr;
+
+	ComPtr<IWICFormatConverter> converter;
+	if(FAILED(hr = factory->CreateFormatConverter(&converter)))
+		return hr;
+	if(FAILED(
+		   hr = converter->Initialize(
+			   scaler.Get(), GUID_WICPixelFormat32bppBGRA,
+			   WICBitmapDitherTypeNone, nullptr, 0.0,
+			   WICBitmapPaletteTypeCustom)))
+		return hr;
+
+	BITMAPINFO bmi{};
+	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmi.bmiHeader.biWidth = static_cast<int32_t>(outW);
+	bmi.bmiHeader.biHeight = -static_cast<int32_t>(outH);
+	bmi.bmiHeader.biPlanes = 1;
+	bmi.bmiHeader.biBitCount = 32;
+	bmi.bmiHeader.biCompression = BI_RGB;
+
+	void *pvBits = nullptr;
+	HDC hdc = GetDC(nullptr);
+	HBITMAP hbm =
+		CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pvBits, nullptr, 0);
+	ReleaseDC(nullptr, hdc);
+	if(!hbm)
+		return E_OUTOFMEMORY;
+
+	const uint32_t stride = outW * 4;
+
+	hr = converter->CopyPixels(
+		nullptr, stride, stride * outH, static_cast<uint8_t *>(pvBits));
+	if(FAILED(hr)) {
+		DeleteObject(hbm);
+		return hr;
+	}
+
+	*phbmp = hbm;
+	return S_OK;
+}

--- a/src/win-shell-ext/dpcs.cpp
+++ b/src/win-shell-ext/dpcs.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "dpcs.h"
 #include <algorithm>
 #include <cstddef>
@@ -16,12 +18,10 @@ HRESULT IStreamToBuffer(IStream *stream, std::vector<unsigned char> &out)
 	if(FAILED(hr = stream->Stat(&stats, STATFLAG_NONAME)))
 		return hr;
 
-	out.resize(static_cast<size_t>(stats.cbSize.QuadPart));
+	out.resize(size_t(stats.cbSize.QuadPart));
 
 	ULONG bytesRead;
-	if(FAILED(
-		   hr = stream->Read(
-			   out.data(), static_cast<uint32_t>(out.size()), &bytesRead)))
+	if(FAILED(hr = stream->Read(out.data(), uint32_t(out.size()), &bytesRead)))
 		return hr;
 
 	if(out.size() > bytesRead) {
@@ -60,7 +60,7 @@ HRESULT ExtractJPEG(sqlite3 *db, std::vector<unsigned char> &out)
 	sqlite3_stmt *stmt;
 	int rc;
 	rc = sqlite3_prepare_v2(
-		db, "SELECT thumbnail FROM snapshots ORDER BY taken_at DESC LIMIT 1",
+		db, "SELECT thumbnail FROM snapshots ORDER BY snapshot_id DESC LIMIT 1",
 		-1, &stmt, nullptr);
 	if(rc != SQLITE_OK) {
 		fprintf(stderr, "Fail to query database: %s\n", sqlite3_errmsg(db));
@@ -104,9 +104,7 @@ JpegToHBitmap(unsigned char *data, size_t size, uint32_t cx, HBITMAP *phbmp)
 	if(FAILED(hr = factory->CreateStream(&wicStream)))
 		return hr;
 	// InitializeFromMemory takes non-const BYTE* but does not modify the buffer
-	if(FAILED(
-		   hr = wicStream->InitializeFromMemory(
-			   data, static_cast<int32_t>(size))))
+	if(FAILED(hr = wicStream->InitializeFromMemory(data, int32_t(size))))
 		return hr;
 
 	ComPtr<IWICBitmapDecoder> decoder;
@@ -125,13 +123,14 @@ JpegToHBitmap(unsigned char *data, size_t size, uint32_t cx, HBITMAP *phbmp)
 		return hr;
 
 	// Scale to fit within cx×cx, maintaining aspect ratio
+	// Do computation with doubles to avoid overflow
 	uint32_t outW, outH;
 	if(srcW >= srcH) {
 		outW = cx;
-		outH = std::max(1u, srcH * cx / srcW);
+		outH = std::max(1u, uint32_t(double(srcH) * double(cx) / double(srcW)));
 	} else {
 		outH = cx;
-		outW = std::max(1u, srcW * cx / srcH);
+		outW = std::max(1u, uint32_t(double(srcW) * double(cx) / double(srcH)));
 	}
 
 	ComPtr<IWICBitmapScaler> scaler;
@@ -154,8 +153,8 @@ JpegToHBitmap(unsigned char *data, size_t size, uint32_t cx, HBITMAP *phbmp)
 
 	BITMAPINFO bmi{};
 	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-	bmi.bmiHeader.biWidth = static_cast<int32_t>(outW);
-	bmi.bmiHeader.biHeight = -static_cast<int32_t>(outH);
+	bmi.bmiHeader.biWidth = int32_t(outW);
+	bmi.bmiHeader.biHeight = -int32_t(outH);
 	bmi.bmiHeader.biPlanes = 1;
 	bmi.bmiHeader.biBitCount = 32;
 	bmi.bmiHeader.biCompression = BI_RGB;

--- a/src/win-shell-ext/dpcs.cpp
+++ b/src/win-shell-ext/dpcs.cpp
@@ -1,5 +1,6 @@
 #include "dpcs.h"
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <intsafe.h>
 #include <wincodec.h>
@@ -15,7 +16,7 @@ HRESULT IStreamToBuffer(IStream *stream, std::vector<unsigned char> &out)
 	if(FAILED(hr = stream->Stat(&stats, STATFLAG_NONAME)))
 		return hr;
 
-	out.resize(stats.cbSize.QuadPart);
+	out.resize(static_cast<size_t>(stats.cbSize.QuadPart));
 
 	ULONG bytesRead;
 	if(FAILED(

--- a/src/win-shell-ext/dpcs.h
+++ b/src/win-shell-ext/dpcs.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+#include <objidl.h>
+#include <sqlite3.h>
+#include <vector>
+#include <windows.h>
+
+HRESULT IStreamToBuffer(IStream *stream, std::vector<unsigned char> &out);
+HRESULT OpenSqlite(std::vector<unsigned char> &databaseBuffer, sqlite3 **out);
+HRESULT ExtractJPEG(sqlite3 *db, std::vector<unsigned char> &out);
+HRESULT
+JpegToHBitmap(unsigned char *data, size_t size, uint32_t cx, HBITMAP *phbmp);

--- a/src/win-shell-ext/dpcs.h
+++ b/src/win-shell-ext/dpcs.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #pragma once
 #include <cstdint>
 #include <objidl.h>

--- a/src/win-shell-ext/exports.def
+++ b/src/win-shell-ext/exports.def
@@ -1,0 +1,7 @@
+LIBRARY drawpile_shell_ext
+
+EXPORTS
+    DllGetClassObject   PRIVATE
+    DllCanUnloadNow     PRIVATE
+    DllRegisterServer   PRIVATE
+    DllUnregisterServer PRIVATE

--- a/src/win-shell-ext/main.cpp
+++ b/src/win-shell-ext/main.cpp
@@ -62,8 +62,11 @@ static constexpr wchar_t kKeyClsid[] =
 static constexpr wchar_t kKeyInproc[] =
 	L"Software\\Classes\\CLSID\\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}"
 	L"\\InprocServer32";
-static constexpr wchar_t kKeyShellEx[] =
+static constexpr wchar_t kKeyShellExDpcs[] =
 	L"Software\\Classes\\.dpcs\\ShellEx\\{E357FCCD-A995-4576-B01F-"
+	L"234630154E96}";
+static constexpr wchar_t kKeyShellExDppr[] =
+	L"Software\\Classes\\.dppr\\ShellEx\\{E357FCCD-A995-4576-B01F-"
 	L"234630154E96}";
 
 STDAPI DllRegisterServer()
@@ -86,7 +89,11 @@ STDAPI DllRegisterServer()
 		return hr;
 	if(FAILED(
 		   hr = SetRegValue(
-			   HKEY_LOCAL_MACHINE, kKeyShellEx, nullptr, kClsidStr)))
+			   HKEY_LOCAL_MACHINE, kKeyShellExDpcs, nullptr, kClsidStr)))
+		return hr;
+	if(FAILED(
+		   hr = SetRegValue(
+			   HKEY_LOCAL_MACHINE, kKeyShellExDppr, nullptr, kClsidStr)))
 		return hr;
 
 	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
@@ -96,7 +103,8 @@ STDAPI DllRegisterServer()
 STDAPI DllUnregisterServer()
 {
 	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyClsid);
-	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyShellEx);
+	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyShellExDpcs);
+	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyShellExDppr);
 
 	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
 	return S_OK;

--- a/src/win-shell-ext/main.cpp
+++ b/src/win-shell-ext/main.cpp
@@ -1,5 +1,7 @@
 #include <cstdint>
 #include <shlobj.h>
+#include <sqlite3.h>
+#include <stdio.h>
 #include <windows.h>
 #include <wrl/module.h>
 
@@ -10,6 +12,12 @@ static HMODULE g_hModule = nullptr;
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID)
 {
 	if(dwReason == DLL_PROCESS_ATTACH) {
+		int rc = sqlite3_initialize();
+		if(rc != SQLITE_OK) {
+			fprintf(stderr, "Cannot initialize SQLite: %d\n", rc);
+			return FALSE;
+		}
+
 		g_hModule = static_cast<HMODULE>(hInstance);
 		DisableThreadLibraryCalls(hInstance);
 	}

--- a/src/win-shell-ext/main.cpp
+++ b/src/win-shell-ext/main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include <cstdint>
 #include <shlobj.h>
 #include <sqlite3.h>
@@ -45,7 +47,7 @@ static HRESULT SetRegValue(
 		nullptr, &hk, nullptr);
 	if(r != ERROR_SUCCESS)
 		return HRESULT_FROM_WIN32(r);
-	uint32_t cb = static_cast<uint32_t>((wcslen(data) + 1) * sizeof(wchar_t));
+	uint32_t cb = uint32_t((wcslen(data) + 1) * sizeof(wchar_t));
 	r = RegSetValueExW(
 		hk, valueName, 0, REG_SZ, reinterpret_cast<const BYTE *>(data), cb);
 	RegCloseKey(hk);

--- a/src/win-shell-ext/main.cpp
+++ b/src/win-shell-ext/main.cpp
@@ -1,0 +1,95 @@
+#include <cstdint>
+#include <shlobj.h>
+#include <windows.h>
+#include <wrl/module.h>
+
+using namespace Microsoft::WRL;
+
+static HMODULE g_hModule = nullptr;
+
+BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID)
+{
+	if(dwReason == DLL_PROCESS_ATTACH) {
+		g_hModule = static_cast<HMODULE>(hInstance);
+		DisableThreadLibraryCalls(hInstance);
+	}
+	return TRUE;
+}
+
+STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
+{
+	return Module<InProc>::GetModule().GetClassObject(rclsid, riid, ppv);
+}
+
+STDAPI DllCanUnloadNow()
+{
+	return Module<InProc>::GetModule().Terminate() == 0 ? S_OK : S_FALSE;
+}
+
+// regsvr32 functions
+static HRESULT SetRegValue(
+	HKEY hRoot, const wchar_t *subKey, const wchar_t *valueName,
+	const wchar_t *data)
+{
+	HKEY hk = nullptr;
+	LONG r = RegCreateKeyExW(
+		hRoot, subKey, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE,
+		nullptr, &hk, nullptr);
+	if(r != ERROR_SUCCESS)
+		return HRESULT_FROM_WIN32(r);
+	uint32_t cb = static_cast<uint32_t>((wcslen(data) + 1) * sizeof(wchar_t));
+	r = RegSetValueExW(
+		hk, valueName, 0, REG_SZ, reinterpret_cast<const BYTE *>(data), cb);
+	RegCloseKey(hk);
+	return HRESULT_FROM_WIN32(r);
+}
+
+static constexpr wchar_t kClsidStr[] =
+	L"{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}";
+static constexpr wchar_t kFriendlyName[] = L"Drawpile Thumbnail Provider";
+static constexpr wchar_t kThreading[] = L"Apartment";
+
+static constexpr wchar_t kKeyClsid[] =
+	L"Software\\Classes\\CLSID\\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}";
+static constexpr wchar_t kKeyInproc[] =
+	L"Software\\Classes\\CLSID\\{3C98D577-6E3D-4C7F-B4A2-1D9F82E5C301}"
+	L"\\InprocServer32";
+static constexpr wchar_t kKeyShellEx[] =
+	L"Software\\Classes\\.dpcs\\ShellEx\\{E357FCCD-A995-4576-B01F-"
+	L"234630154E96}";
+
+STDAPI DllRegisterServer()
+{
+	wchar_t szPath[MAX_PATH] = {};
+	if(!GetModuleFileNameW(g_hModule, szPath, MAX_PATH))
+		return HRESULT_FROM_WIN32(GetLastError());
+
+	HRESULT hr;
+	if(FAILED(
+		   hr = SetRegValue(
+			   HKEY_LOCAL_MACHINE, kKeyClsid, nullptr, kFriendlyName)))
+		return hr;
+	if(FAILED(
+		   hr = SetRegValue(HKEY_LOCAL_MACHINE, kKeyInproc, nullptr, szPath)))
+		return hr;
+	if(FAILED(
+		   hr = SetRegValue(
+			   HKEY_LOCAL_MACHINE, kKeyInproc, L"ThreadingModel", kThreading)))
+		return hr;
+	if(FAILED(
+		   hr = SetRegValue(
+			   HKEY_LOCAL_MACHINE, kKeyShellEx, nullptr, kClsidStr)))
+		return hr;
+
+	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+	return S_OK;
+}
+
+STDAPI DllUnregisterServer()
+{
+	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyClsid);
+	RegDeleteTreeW(HKEY_LOCAL_MACHINE, kKeyShellEx);
+
+	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+	return S_OK;
+}

--- a/src/win-shell-ext/test_main.cpp
+++ b/src/win-shell-ext/test_main.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include <cstdint>
 #include <objbase.h>
 #include <shlwapi.h>

--- a/src/win-shell-ext/test_main.cpp
+++ b/src/win-shell-ext/test_main.cpp
@@ -1,0 +1,132 @@
+#include <cstdint>
+#include <objbase.h>
+#include <shlwapi.h>
+#include <stdio.h>
+#include <thumbcache.h>
+#include <windows.h>
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+
+static const CLSID CLSID_ThumbProvider = {
+	0x3C98D577,
+	0x6E3D,
+	0x4C7F,
+	{0xB4, 0xA2, 0x1D, 0x9F, 0x82, 0xE5, 0xC3, 0x01}};
+
+static void SaveBmp(const wchar_t *path, HBITMAP hbm)
+{
+	BITMAP bm{};
+	if(!GetObject(hbm, sizeof(bm), &bm))
+		return;
+
+	const LONG w = bm.bmWidth;
+	const LONG h = abs(bm.bmHeight);
+	const uint32_t pixBytes = static_cast<uint32_t>(w * h * 4);
+
+	BITMAPINFOHEADER bih{};
+	bih.biSize = sizeof(bih);
+	bih.biWidth = w;
+	bih.biHeight = h;
+	bih.biPlanes = 1;
+	bih.biBitCount = 32;
+	bih.biCompression = BI_RGB;
+
+	BITMAPFILEHEADER bfh{};
+	bfh.bfType = 0x4D42;
+	bfh.bfSize = static_cast<DWORD>(sizeof(bfh) + sizeof(bih) + pixBytes);
+	bfh.bfOffBits = sizeof(bfh) + sizeof(bih);
+
+	void *pixels = HeapAlloc(GetProcessHeap(), 0, pixBytes);
+	if(!pixels)
+		return;
+
+	BITMAPINFO bi{};
+	bi.bmiHeader = bih;
+	HDC hdc = GetDC(nullptr);
+	GetDIBits(hdc, hbm, 0, static_cast<UINT>(h), pixels, &bi, DIB_RGB_COLORS);
+	ReleaseDC(nullptr, hdc);
+
+	HANDLE hf = CreateFileW(
+		path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+		nullptr);
+	if(hf != INVALID_HANDLE_VALUE) {
+		DWORD written;
+		WriteFile(hf, &bfh, sizeof(bfh), &written, nullptr);
+		WriteFile(hf, &bih, sizeof(bih), &written, nullptr);
+		WriteFile(hf, pixels, pixBytes, &written, nullptr);
+		CloseHandle(hf);
+		wprintf(L"Saved %s (%ldx%ld)\n", path, w, h);
+	}
+	HeapFree(GetProcessHeap(), 0, pixels);
+}
+
+int wmain()
+{
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	if(FAILED(hr)) {
+		wprintf(L"CoInitializeEx: 0x%08lX\n", static_cast<unsigned long>(hr));
+		return 1;
+	}
+
+	// All ComPtrs live inside this lambda so they're Released before
+	// CoUninitialize().
+	const int exitCode = []() -> int {
+		HRESULT hr;
+
+		ComPtr<IInitializeWithStream> pInit;
+		hr = CoCreateInstance(
+			CLSID_ThumbProvider, nullptr, CLSCTX_INPROC_SERVER,
+			IID_PPV_ARGS(&pInit));
+		if(FAILED(hr)) {
+			wprintf(
+				L"CoCreateInstance: 0x%08lX\n", static_cast<unsigned long>(hr));
+			return 1;
+		}
+
+		ComPtr<IStream> pStream;
+		hr = SHCreateStreamOnFileEx(
+			L"test.dpcs", STGM_READ | STGM_SHARE_DENY_WRITE, 0, FALSE, nullptr,
+			&pStream);
+		if(FAILED(hr)) {
+			wprintf(
+				L"SHCreateStreamOnFileEx: 0x%08lX\n",
+				static_cast<unsigned long>(hr));
+			return 1;
+		}
+
+		hr = pInit->Initialize(pStream.Get(), STGM_READ);
+		if(FAILED(hr)) {
+			wprintf(L"Initialize: 0x%08lX\n", static_cast<unsigned long>(hr));
+			return 1;
+		}
+
+		ComPtr<IThumbnailProvider> pThumb;
+		hr = pInit.As(&pThumb);
+		if(FAILED(hr)) {
+			wprintf(
+				L"QI(IThumbnailProvider): 0x%08lX\n",
+				static_cast<unsigned long>(hr));
+			return 1;
+		}
+
+		constexpr unsigned int kSize = 256;
+		HBITMAP hbm = nullptr;
+		WTS_ALPHATYPE alphaType = WTSAT_UNKNOWN;
+		hr = pThumb->GetThumbnail(kSize, &hbm, &alphaType);
+		if(FAILED(hr) || !hbm) {
+			wprintf(L"GetThumbnail: 0x%08lX\n", static_cast<unsigned long>(hr));
+			return 1;
+		}
+
+		wprintf(
+			L"GetThumbnail OK  size=%u  alphaType=%d\n", kSize,
+			static_cast<int>(alphaType));
+		SaveBmp(L"thumbnail.bmp", hbm);
+		DeleteObject(hbm);
+		return 0;
+	}();
+
+	CoUninitialize();
+	return exitCode;
+}


### PR DESCRIPTION
## Description

Adds `drawpile_shell_ext.dll` on windows. This is a shell extension that provides thumbnails for `.dpcs` files.   
The WIX installer has been updated to register the DLL as a shell extension.  
The code is self contained, only relying on windows libraries (WRL for COM) and sqlite3. WIC (Windows Imaging Component) is used to parse the JPEG thumbnail inside the `.dpcs` file.

The PR also contains a simple test exe that loads the provider via COM and outputs a single thumbnail. I used it to test the shell extension and use a debugger, without having to rely on the file explorer.

The extension can be expanded in the future to support more file formats or other windows integration.

## Formalities

* Did you write the code yourself or was any AI-assistance or similar used? If it's the latter, describe what.

I did use LLMs to understand various windows APIs.