### PR TITLE
Use native image fallback for file image imports

### DIFF
--- a/src/desktop/docks/reference.cpp
+++ b/src/desktop/docks/reference.cpp
@@ -7,10 +7,10 @@
 #include "desktop/widgets/kis_slider_spin_box.h"
 #include "desktop/widgets/referenceview.h"
 #include "libclient/document.h"
+#include "libclient/utils/images.h"
 #include <QAction>
 #include <QButtonGroup>
 #include <QHBoxLayout>
-#include <QImageReader>
 #include <QMenu>
 #include <QScrollBar>
 #include <QSignalBlocker>
@@ -237,14 +237,8 @@ void ReferenceDock::handleImageDrop(const QImage &img)
 
 void ReferenceDock::handlePathDrop(const QString &path)
 {
-	QImage img;
 	QString error;
-	{
-		QImageReader reader(path);
-		if(!reader.read(&img)) {
-			error = reader.errorString();
-		}
-	}
+	QImage img = utils::loadImageFromFile(path, &error);
 	showReferenceImageFromFile(img, error);
 }
 

--- a/src/desktop/filewrangler.cpp
+++ b/src/desktop/filewrangler.cpp
@@ -1070,14 +1070,8 @@ void FileWrangler::openImageFileContent(
 		};
 #else
 	OpenFn fileOpenCompleted = [imageOpenCompleted](const QString &fileName) {
-		QImage img;
 		QString error;
-		{
-			QImageReader reader(fileName);
-			if(!reader.read(&img)) {
-				error = reader.errorString();
-			}
-		}
+		QImage img = utils::loadImageFromFile(fileName, &error);
 		imageOpenCompleted(img, error);
 	};
 #endif

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -5406,10 +5406,14 @@ void MainWindow::pasteFile()
 void MainWindow::pasteFilePath(const QString &path)
 {
 	QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-	QImage img(path);
+	QString error;
+	QImage img = utils::loadImageFromFile(path, &error);
 	if(img.isNull()) {
 		QGuiApplication::restoreOverrideCursor();
-		showErrorMessage(tr("The image could not be loaded"));
+		showErrorMessage(
+			error.isEmpty() ? tr("The image could not be loaded")
+							: tr("The image could not be loaded: %1.")
+								  .arg(error));
 	} else {
 		pasteImage(img);
 		QGuiApplication::restoreOverrideCursor();

--- a/src/desktop/scene/canvasview.cpp
+++ b/src/desktop/scene/canvasview.cpp
@@ -2835,7 +2835,12 @@ void CanvasView::dropEvent(QDropEvent *event)
 void CanvasView::handleDragDrop(QDropEvent *event, bool drop)
 {
 	const QMimeData *mimeData = event->mimeData();
-	if(mimeData->hasImage()) {
+	if(mimeData->hasUrls() && !mimeData->urls().isEmpty()) {
+		event->acceptProposedAction();
+		if(drop) {
+			emit urlDropped(mimeData->urls().first());
+		}
+	} else if(mimeData->hasImage()) {
 		// Don't accept layer drops from the same canvas, that just leads to
 		// accidental dragging of layers duplicating their contents.
 		if(!qobject_cast<const canvas::LayerMimeData *>(mimeData)) {
@@ -2843,11 +2848,6 @@ void CanvasView::handleDragDrop(QDropEvent *event, bool drop)
 			if(drop) {
 				emit imageDropped(qvariant_cast<QImage>(mimeData->imageData()));
 			}
-		}
-	} else if(mimeData->hasUrls() && !mimeData->urls().isEmpty()) {
-		event->acceptProposedAction();
-		if(drop) {
-			emit urlDropped(mimeData->urls().first());
 		}
 	} else if(mimeData->hasColor()) {
 		event->acceptProposedAction();

--- a/src/desktop/view/canvasview.cpp
+++ b/src/desktop/view/canvasview.cpp
@@ -380,7 +380,12 @@ void CanvasView::setTouchUseGestureEvents(bool touchUseGestureEvents)
 void CanvasView::handleDragDrop(QDropEvent *event, bool drop)
 {
 	const QMimeData *mimeData = event->mimeData();
-	if(mimeData->hasImage()) {
+	if(mimeData->hasUrls() && !mimeData->urls().isEmpty()) {
+		event->acceptProposedAction();
+		if(drop) {
+			emit urlDropped(mimeData->urls().first());
+		}
+	} else if(mimeData->hasImage()) {
 		// Don't accept layer drops from the same canvas, that just leads to
 		// accidental dragging of layers duplicating their contents.
 		if(!qobject_cast<const canvas::LayerMimeData *>(mimeData)) {
@@ -388,11 +393,6 @@ void CanvasView::handleDragDrop(QDropEvent *event, bool drop)
 			if(drop) {
 				emit imageDropped(qvariant_cast<QImage>(mimeData->imageData()));
 			}
-		}
-	} else if(mimeData->hasUrls() && !mimeData->urls().isEmpty()) {
-		event->acceptProposedAction();
-		if(drop) {
-			emit urlDropped(mimeData->urls().first());
 		}
 	} else if(mimeData->hasColor()) {
 		event->acceptProposedAction();

--- a/src/desktop/widgets/referenceview.cpp
+++ b/src/desktop/widgets/referenceview.cpp
@@ -2,6 +2,7 @@
 #include "desktop/widgets/referenceview.h"
 #include "desktop/utils/qtguicompat.h"
 #include "libclient/utils/cursors.h"
+#include "libclient/utils/images.h"
 #include "libclient/view/zoom.h"
 #include <QDragEnterEvent>
 #include <QDragMoveEvent>
@@ -11,7 +12,6 @@
 #include <QGraphicsScene>
 #include <QGuiApplication>
 #include <QImage>
-#include <QImageReader>
 #include <QKeyEvent>
 #include <QMimeData>
 #include <QMouseEvent>
@@ -436,8 +436,7 @@ bool ReferenceView::canHandleDrop(const QMimeData *mimeData)
 			QUrl url = mimeData->urls().first();
 			if(url.isLocalFile()) {
 				QFileInfo info(url.toLocalFile());
-				if(QImageReader::supportedImageFormats().contains(
-					   info.suffix().toCaseFolded().toUtf8())) {
+				if(utils::isLoadableImageFileSuffix(info.suffix())) {
 					return true;
 				}
 			}

--- a/src/libclient/utils/images.cpp
+++ b/src/libclient/utils/images.cpp
@@ -2,12 +2,17 @@
 
 #include "libclient/utils/images.h"
 #include "cmake-config/config.h"
+#include "libclient/drawdance/image.h"
 
 extern "C" {
+#include <dpcommon/input.h>
+#include <dpimpex/image_impex.h>
 #include <dpimpex/load.h>
 #include <dpimpex/save.h>
 }
 
+#include <QFileInfo>
+#include <QImage>
 #include <QSize>
 #include <QImageReader>
 #include <QImageWriter>
@@ -37,6 +42,127 @@ static const QVector<ImageFormat> &writableImageFormats()
 	return formats;
 }
 
+static QString normalizedSuffix(QString suffix)
+{
+	if(suffix.startsWith('.')) {
+		suffix.remove(0, 1);
+	}
+	return suffix.toCaseFolded();
+}
+
+static bool suffixMatchesPatternList(const QString &suffix, const char *patterns)
+{
+	const QString normalized = normalizedSuffix(suffix);
+	for(const QString &pattern :
+		QString::fromUtf8(patterns).split(' ', Qt::SkipEmptyParts)) {
+		QString extension = pattern;
+		if(extension.startsWith(QStringLiteral("*."))) {
+			extension.remove(0, 2);
+		}
+		if(normalized == extension.toCaseFolded()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void appendUniqueImagePattern(QStringList &patterns, const QString &pattern)
+{
+	if(!patterns.contains(pattern, Qt::CaseInsensitive)) {
+		patterns.append(pattern);
+	}
+}
+
+static QString qtAndNativeFlatImageFilterPatterns()
+{
+	QStringList patterns;
+	for(QByteArray format : QImageReader::supportedImageFormats()) {
+		appendUniqueImagePattern(
+			patterns,
+			QStringLiteral("*.%1").arg(QString::fromLatin1(format)));
+	}
+	for(const QString &pattern : QString::fromUtf8(
+			cmake_config::file_group::flatImage())
+								  .split(' ', Qt::SkipEmptyParts)) {
+		appendUniqueImagePattern(patterns, pattern);
+	}
+	return patterns.join(' ');
+}
+
+static QImage loadImageWithQt(const QString &path, QString &outError)
+{
+	QImage img;
+	QImageReader reader(path);
+	if(reader.read(&img) && !img.isNull()) {
+		outError.clear();
+		return img;
+	} else {
+		outError = reader.errorString();
+		return QImage{};
+	}
+}
+
+static QImage loadImageWithDrawdance(const QString &path, QString &outError)
+{
+	QByteArray pathBytes = path.toUtf8();
+	DP_Input *input = DP_file_input_new_from_path(pathBytes.constData());
+	if(!input) {
+		outError = QString::fromUtf8(DP_error());
+		return QImage{};
+	}
+
+	DP_Image *img =
+		DP_image_new_from_file(input, DP_IMAGE_FILE_TYPE_GUESS, nullptr);
+	DP_input_free(input);
+	if(img) {
+		outError.clear();
+		return drawdance::wrapImage(img);
+	} else {
+		outError = QString::fromUtf8(DP_error());
+		return QImage{};
+	}
+}
+
+bool isLoadableImageFileSuffix(const QString &suffix)
+{
+	return QImageReader::supportedImageFormats().contains(
+			   normalizedSuffix(suffix).toUtf8()) ||
+		   suffixMatchesPatternList(suffix, cmake_config::file_group::flatImage());
+}
+
+QImage loadImageFromFile(const QString &path, QString *outError)
+{
+	const QString suffix = QFileInfo(path).suffix();
+	const bool preferDrawdance =
+		suffix.compare(QStringLiteral("webp"), Qt::CaseInsensitive) == 0 ||
+		suffix.compare(QStringLiteral("qoi"), Qt::CaseInsensitive) == 0;
+
+	QString primaryError;
+	QString fallbackError;
+	QImage img = preferDrawdance ? loadImageWithDrawdance(path, primaryError)
+								 : loadImageWithQt(path, primaryError);
+	if(!img.isNull()) {
+		if(outError) {
+			outError->clear();
+		}
+		return img;
+	}
+
+	img = preferDrawdance ? loadImageWithQt(path, fallbackError)
+						  : loadImageWithDrawdance(path, fallbackError);
+	if(!img.isNull()) {
+		if(outError) {
+			outError->clear();
+		}
+		return img;
+	}
+
+	if(outError) {
+		*outError = fallbackError.isEmpty() ? primaryError : fallbackError;
+	}
+	return QImage{};
+}
+
 QStringList fileFormatFilterList(FileFormatOptions formats)
 {
 	QStringList filter;
@@ -62,9 +188,7 @@ QStringList fileFormatFilterList(FileFormatOptions formats)
 		} else {
 			// A single Images filter for loading
 			if(formats.testFlag(FileFormatOption::QtImagesOnly)) {
-				for(QByteArray format : QImageReader::supportedImageFormats()) {
-					readImages += "*." + format + " ";
-				}
+				readImages = qtAndNativeFlatImageFilterPatterns();
 			} else {
 				readImages = cmake_config::file_group::image();
 			}

--- a/src/libclient/utils/images.h
+++ b/src/libclient/utils/images.h
@@ -6,9 +6,11 @@
 class QSize;
 class QImage;
 class QColor;
+class QString;
 
 #include <QVector>
 #include <QPair>
+#include <QStringList>
 
 namespace utils {
 
@@ -56,8 +58,9 @@ Q_DECLARE_FLAGS(FileFormatOptions, FileFormatOption)
 Q_DECLARE_OPERATORS_FOR_FLAGS(FileFormatOptions)
 
 QStringList fileFormatFilterList(FileFormatOptions formats);
+QImage loadImageFromFile(const QString &path, QString *outError = nullptr);
+bool isLoadableImageFileSuffix(const QString &suffix);
 
 }
 
 #endif
-


### PR DESCRIPTION
## Description

Fixes #1574.

This makes file-based image imports use a shared loader that tries both Qt image loading and Drawdance's native image importer. WebP and QOI prefer the native importer first, then fall back to Qt, while other formats keep the Qt-first behavior.

It also makes canvas drag/drop prefer local file URLs before decoded image MIME data, so dropped files can use the same file import path as manual opens instead of depending on the desktop environment's decoded image payload.

Covered entry points include:

- opening image file content
- pasting a file path
- canvas file drops
- reference image drops

## Formalities

* Is the code new or is it based on another project? If it's the latter, explain where so we can double-check the licenses.

The code is new. It was developed in a GPLv3 fork of Drawpile and is being contributed back under Drawpile's existing license. No code was copied from another project.

* Did you write the code yourself or was any AI-assistance or similar used? If it's the latter, describe what.

AI assistance was used to help identify the inconsistent import paths, draft the initial implementation, and isolate the patch into this upstream-focused branch. The changes were reviewed locally before submission.

## Testing

- `git diff --check upstream/main...HEAD`
- `ninja -C build-qt5-client-baseline drawpile`