### PR TITLE
fix: load WebP/QOI via Drawdance on drop and paste

### DIFF
--- a/src/desktop/docks/reference.cpp
+++ b/src/desktop/docks/reference.cpp
@@ -6,11 +6,11 @@
 #include "desktop/widgets/groupedtoolbutton.h"
 #include "desktop/widgets/kis_slider_spin_box.h"
 #include "desktop/widgets/referenceview.h"
+#include "libclient/drawdance/image.h"
 #include "libclient/document.h"
 #include <QAction>
 #include <QButtonGroup>
 #include <QHBoxLayout>
-#include <QImageReader>
 #include <QMenu>
 #include <QScrollBar>
 #include <QSignalBlocker>
@@ -237,14 +237,8 @@ void ReferenceDock::handleImageDrop(const QImage &img)
 
 void ReferenceDock::handlePathDrop(const QString &path)
 {
-	QImage img;
 	QString error;
-	{
-		QImageReader reader(path);
-		if(!reader.read(&img)) {
-			error = reader.errorString();
-		}
-	}
+	QImage img = drawdance::loadImage(path, &error);
 	showReferenceImageFromFile(img, error);
 }
 

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -85,6 +85,7 @@ extern "C" {
 #include "libclient/config/config.h"
 #include "libclient/document.h"
 #include "libclient/drawdance/eventlog.h"
+#include "libclient/drawdance/image.h"
 #include "libclient/drawdance/perf.h"
 #include "libclient/export/animationsaverrunnable.h"
 #include "libclient/import/canvasloaderrunnable.h"
@@ -5407,7 +5408,7 @@ void MainWindow::pasteFile()
 void MainWindow::pasteFilePath(const QString &path)
 {
 	QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-	QImage img(path);
+	QImage img = drawdance::loadImage(path);
 	if(img.isNull()) {
 		QGuiApplication::restoreOverrideCursor();
 		showErrorMessage(tr("The image could not be loaded"));

--- a/src/desktop/widgets/referenceview.cpp
+++ b/src/desktop/widgets/referenceview.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "desktop/widgets/referenceview.h"
+#include "cmake-config/config.h"
 #include "desktop/utils/qtguicompat.h"
 #include "libclient/utils/cursors.h"
 #include "libclient/view/zoom.h"
+#include "libshared/util/qtcompat.h"
 #include <QDragEnterEvent>
 #include <QDragMoveEvent>
 #include <QDropEvent>
@@ -23,6 +25,31 @@
 #include <QWheelEvent>
 
 namespace widgets {
+
+static bool isLoadableImageSuffix(const QString &suffix)
+{
+	QByteArray suffixUtf8 = suffix.toCaseFolded().toUtf8();
+	if(QImageReader::supportedImageFormats().contains(suffixUtf8)) {
+		return true;
+	}
+
+	// Only the flat image formats can be decoded by drawdance::loadImage (used
+	// by handlePathDrop); layered formats like ORA/PSD are not loadable here.
+	const QString globs =
+		QString::fromUtf8(cmake_config::file_group::flatImage());
+	const QList<QString> tokens =
+		globs.split(QLatin1Char(' '), compat::SkipEmptyParts);
+	for(const QString &token : tokens) {
+		QString ext = token;
+		if(ext.startsWith(QStringLiteral("*."))) {
+			ext = ext.mid(2);
+		}
+		if(!ext.isEmpty() && suffix.compare(ext, Qt::CaseInsensitive) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
 
 class ReferenceView::ReferenceItem : public QGraphicsItem {
 public:
@@ -436,8 +463,7 @@ bool ReferenceView::canHandleDrop(const QMimeData *mimeData)
 			QUrl url = mimeData->urls().first();
 			if(url.isLocalFile()) {
 				QFileInfo info(url.toLocalFile());
-				if(QImageReader::supportedImageFormats().contains(
-					   info.suffix().toCaseFolded().toUtf8())) {
+				if(isLoadableImageSuffix(info.suffix())) {
 					return true;
 				}
 			}

--- a/src/libclient/document.cpp
+++ b/src/libclient/document.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "libclient/canvas/userlist.h"
 #include "libclient/config/config.h"
 #include "libclient/document.h"
+#include "libclient/drawdance/image.h"
 #include "libclient/export/canvassaverrunnable.h"
 #include "libclient/export/projectsaver.h"
 #include "libclient/export/thumbnailerrunnable.h"
@@ -33,6 +34,7 @@ extern "C" {
 #include <QGuiApplication>
 #include <QPainter>
 #include <QRunnable>
+#include <QStringList>
 #include <QSysInfo>
 #include <QTemporaryDir>
 #include <QThreadPool>
@@ -2330,8 +2332,19 @@ const QMimeData *Document::getClipboardData()
 bool Document::clipboardHasImageData()
 {
 	const QMimeData *mimeData = getClipboardData();
-	return mimeData && (mimeData->hasImage() ||
-						mimeData->hasFormat(QStringLiteral("image/png")));
+	if(!mimeData) {
+		return false;
+	}
+	if(mimeData->hasImage()) {
+		return true;
+	}
+	const QStringList formats = mimeData->formats();
+	for(const QString &format : formats) {
+		if(format.startsWith(QStringLiteral("image/"))) {
+			return true;
+		}
+	}
+	return false;
 }
 
 QImage Document::getClipboardImageData(const QMimeData *mimeData)
@@ -2339,11 +2352,25 @@ QImage Document::getClipboardImageData(const QMimeData *mimeData)
 	if(mimeData) {
 		if(mimeData->hasImage()) {
 			return mimeData->imageData().value<QImage>();
-		} else if(mimeData->hasFormat(QStringLiteral("image/png"))) {
-			QImage img;
-			if(img.loadFromData(
-				   mimeData->data(QStringLiteral("image/png")), "PNG")) {
+		}
+		// Try raw image byte buffers (e.g. image/png, image/webp) through the
+		// Drawdance loader so formats like WebP and QOI decode the same as
+		// they do via File > Open.
+		const QString pngFormat = QStringLiteral("image/png");
+		if(mimeData->hasFormat(pngFormat)) {
+			QImage img = drawdance::loadImage(mimeData->data(pngFormat));
+			if(!img.isNull()) {
 				return img;
+			}
+		}
+		const QStringList formats = mimeData->formats();
+		for(const QString &format : formats) {
+			if(format != pngFormat &&
+			   format.startsWith(QStringLiteral("image/"))) {
+				QImage img = drawdance::loadImage(mimeData->data(format));
+				if(!img.isNull()) {
+					return img;
+				}
 			}
 		}
 	}

--- a/src/libclient/drawdance/image.cpp
+++ b/src/libclient/drawdance/image.cpp
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 extern "C" {
 #include <dpcommon/geom.h>
+#include <dpcommon/input.h>
 #include <dpengine/image.h>
+#include <dpimpex/image_impex.h>
 }
 #include "libclient/drawdance/global.h"
 #include "libclient/drawdance/image.h"
+#include <QImageReader>
 
 static void cleanupImage(void *user)
 {
@@ -26,6 +29,19 @@ static DP_Pixel8 getPixel(void *user, int x, int y)
 
 namespace drawdance {
 
+static QImage decodeWithDrawdance(DP_Input *input)
+{
+	// input is consumed/freed here.
+	DP_Image *dpImg = input
+						  ? DP_image_new_from_file(
+								input, DP_IMAGE_FILE_TYPE_GUESS, nullptr)
+						  : nullptr;
+	if(input) {
+		DP_input_free(input);
+	}
+	return wrapImage(dpImg);
+}
+
 QImage wrapImage(DP_Image *img)
 {
 	if(img) {
@@ -39,6 +55,48 @@ QImage wrapImage(DP_Image *img)
 	} else {
 		return QImage{};
 	}
+}
+
+QImage loadImage(const QString &path, QString *outError)
+{
+	QByteArray pathBytes = path.toUtf8();
+	DP_Input *input = DP_file_input_new_from_path(pathBytes.constData());
+	QImage img = decodeWithDrawdance(input);
+	if(!img.isNull()) {
+		return img;
+	}
+
+	QImageReader reader(path);
+	QImage qtImg;
+	if(reader.read(&qtImg)) {
+		return qtImg;
+	}
+	if(outError) {
+		*outError = reader.errorString();
+	}
+	return QImage();
+}
+
+QImage loadImage(const QByteArray &bytes, QString *outError)
+{
+	DP_Input *input = bytes.isEmpty()
+						  ? nullptr
+						  : DP_mem_input_new_keep_on_close(
+								bytes.constData(),
+								static_cast<size_t>(bytes.size()));
+	QImage img = decodeWithDrawdance(input);
+	if(!img.isNull()) {
+		return img;
+	}
+
+	QImage qtImg;
+	if(qtImg.loadFromData(bytes)) {
+		return qtImg;
+	}
+	if(outError) {
+		*outError = QStringLiteral("Unsupported or corrupt image data");
+	}
+	return QImage();
 }
 
 QImage wrapPixels8(int width, int height, DP_Pixel8 *pixels)

--- a/src/libclient/drawdance/image.h
+++ b/src/libclient/drawdance/image.h
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DRAWDANCE_IMAGE_H
 #define DRAWDANCE_IMAGE_H
+#include <QByteArray>
 #include <QImage>
+#include <QString>
 
 typedef struct DP_Image DP_Image;
 typedef union DP_Pixel8 DP_Pixel8;
@@ -9,6 +11,15 @@ typedef union DP_Pixel8 DP_Pixel8;
 namespace drawdance {
 
 QImage wrapImage(DP_Image *img);
+
+// Decodes an image file at `path` using the Drawdance impex loader (which
+// supports WebP and QOI in addition to PNG/JPEG), falling back to Qt's
+// QImage loader when Drawdance can't decode it. Returns a null QImage on
+// failure; when `outError` is non-null it receives an error description.
+QImage loadImage(const QString &path, QString *outError = nullptr);
+
+// Decodes in-memory image bytes the same way. Used for clipboard/drop data.
+QImage loadImage(const QByteArray &bytes, QString *outError = nullptr);
 
 QImage wrapPixels8(int width, int height, DP_Pixel8 *pixels);
 


### PR DESCRIPTION
## Description

Dropping or pasting a WebP file (and likewise QOI) could fail to open even though `File > Open` loads the same file fine. The two paths used different decoders: `File > Open` goes through the Drawdance impex layer (`DP_image_new_from_file`), which supports WebP/QOI, while drop/paste/reference went through Qt's loader (`QImageReader` / `QImage(path)` / `QImage::loadFromData`), which lacks those decoders. A member confirmed this root cause on the issue.

This consolidates the loading so dropped and pasted images support the same formats as opened files. Fixes #1574.

Changes:

- `src/libclient/drawdance/image.{h,cpp}`: add `drawdance::loadImage` helpers (one for a file path, one for an in-memory `QByteArray`) that decode through the Drawdance impex loader and fall back to Qt's loader only when Drawdance returns nothing, so formats Qt already handles are unaffected.
- `src/desktop/docks/reference.cpp`: route the reference-dock file drop through `drawdance::loadImage`.
- `src/libclient/document.cpp`: `getClipboardImageData` keeps the native in-memory `QImage` fast path, then decodes raw `image/*` clipboard byte buffers (e.g. `image/png`, `image/webp`) through `drawdance::loadImage`. `clipboardHasImageData` now also reports image data when the clipboard advertises any raw `image/*` format, so the Paste action is enabled for WebP/QOI.
- `src/desktop/mainwindow.cpp`: route the dropped-file paste path (`pasteFilePath`) through `drawdance::loadImage`.
- `src/desktop/widgets/referenceview.cpp`: accept reference-dock file drops for the Drawdance flat image formats (`cmake_config::file_group::flatImage()`: PNG/JPEG/QOI/WEBP) in addition to Qt-supported formats, so QOI (and WebP on builds without Qt's WebP plugin) is no longer rejected before `handlePathDrop` runs.

Native in-memory `QImage` clipboard data keeps its existing fast path; only raw byte buffers and file paths gain the Drawdance fallback.

Testing: I could not run a full Qt+Rust build locally. The changes were verified for syntactic consistency, helper-signature/call-site wiring, and Drawdance API correctness (`DP_file_input_new_from_path`, `DP_mem_input_new_keep_on_close`, `DP_input_free`, `DP_image_new_from_file`, and `drawdance::wrapImage` ownership). Suggested manual checks: drop/paste a `.webp` and `.qoi` onto the canvas and reference dock (should open), and confirm PNG/JPEG plus native in-memory `QImage` clipboard data still work as before.

## Formalities

* Is the code new or is it based on another project? If it's the latter, explain where so we can double-check the licenses.

The code is new. It reuses Drawpile's existing Drawdance impex loader (`DP_image_new_from_file`) and the existing `drawdance::wrapImage` helper, both already in this repository; no external code was brought in.

* Did you write the code yourself or was any AI-assistance or similar used? If it's the latter, describe what.

AI assistance was used to help draft the decode helper and route the three call sites, followed by manual review of the Drawdance API usage, memory ownership, and the format-gating logic.

Fixes #1574
