### PR TITLE
Fix JPEG export in drawpile-cmd on Windows

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 set_property(SOURCE dprectool/main.c PROPERTY SKIP_AUTOGEN ON)
-set_property(SOURCE drawpile-cmd/main.c PROPERTY SKIP_AUTOGEN ON)
+set_property(SOURCE drawpile-cmd/main.cpp PROPERTY SKIP_AUTOGEN ON)
 
 add_cargo_library(dprectool_rust dprectool)
 add_executable(dprectool dprectool/main.c)
@@ -10,10 +10,11 @@ target_link_libraries(
     dprectool PUBLIC dprectool_rust drawdance_client cmake-config)
 
 add_cargo_library(drawpile-cmd_rust drawpilecmd)
-add_executable(drawpile-cmd drawpile-cmd/main.c)
+add_executable(drawpile-cmd drawpile-cmd/main.cpp)
 dp_sign_executable(drawpile-cmd)
 target_link_libraries(
-    drawpile-cmd PUBLIC drawpile-cmd_rust drawdance_client cmake-config)
+    drawpile-cmd PUBLIC Qt${QT_VERSION_MAJOR}::Core drawpile-cmd_rust
+    drawdance_client cmake-config)
 
 add_cargo_library(drawpile-timelapse_rust drawpiletimelapse)
 add_executable(
@@ -24,3 +25,15 @@ target_link_libraries(drawpile-timelapse PUBLIC
     cmake-config)
 
 dp_install_executables(TARGETS dprectool drawpile-cmd drawpile-timelapse)
+
+if(TESTS)
+    add_test(
+        NAME drawpile_cmd_jpeg
+        COMMAND
+            "${CMAKE_COMMAND}"
+            "-DDRAWPILE_CMD=$<TARGET_FILE:drawpile-cmd>"
+            "-DINPUT_IMAGE=${PROJECT_SOURCE_DIR}/test/data/logo256x256.png"
+            "-DOUTPUT_IMAGE=${CMAKE_CURRENT_BINARY_DIR}/drawpile-cmd-test.jpg"
+            -P "${CMAKE_CURRENT_LIST_DIR}/drawpile-cmd/test_jpeg.cmake"
+    )
+endif()

--- a/src/tools/drawpile-cmd/main.c
+++ b/src/tools/drawpile-cmd/main.c
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-
-int drawpile_cmd_main(void);
-
-int main(void)
-{
-    return drawpile_cmd_main();
-}

--- a/src/tools/drawpile-cmd/main.cpp
+++ b/src/tools/drawpile-cmd/main.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QCoreApplication>
+
+extern "C" int drawpile_cmd_main(void);
+
+int main(int argc, char *argv[])
+{
+	QCoreApplication app(argc, argv);
+	return drawpile_cmd_main();
+}

--- a/src/tools/drawpile-cmd/test_jpeg.cmake
+++ b/src/tools/drawpile-cmd/test_jpeg.cmake
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+execute_process(
+	COMMAND "${DRAWPILE_CMD}" -f jpg -o "${OUTPUT_IMAGE}" -i "${INPUT_IMAGE}"
+	RESULT_VARIABLE result
+	OUTPUT_VARIABLE stdout
+	ERROR_VARIABLE stderr
+)
+
+if(NOT result EQUAL 0)
+	message(FATAL_ERROR
+		"drawpile-cmd JPEG export failed with exit code ${result}\n"
+		"stdout:\n${stdout}\n"
+		"stderr:\n${stderr}"
+	)
+endif()
+
+file(READ "${OUTPUT_IMAGE}" jpeg_header LIMIT 3 HEX)
+file(REMOVE "${OUTPUT_IMAGE}")
+
+if(NOT jpeg_header STREQUAL "ffd8ff")
+	message(FATAL_ERROR
+		"drawpile-cmd output is not a JPEG (header: ${jpeg_header})"
+	)
+endif()


### PR DESCRIPTION
## Description

`drawpile-cmd` uses Qt image I/O when it is built alongside the client or server. On Windows, JPEG support is provided by the deployed `qjpeg` plugin, but the command did not create a `QCoreApplication`, so Qt did not initialize its application/plugin search paths and JPEG export failed with `Unsupported image format`.

This changes the command entry point to C++, keeps a `QCoreApplication` alive for the command lifetime, and adds an end-to-end CTest that converts the existing PNG fixture to JPEG and verifies the `FF D8 FF` signature.

Fixes #1582.

## Validation

- `cargo test --package drawpilecmd`
- `cargo clippy --package drawpilecmd -- ...` (completed with pre-existing warnings)
- `cargo doc --package drawpilecmd --no-deps`
- Clang syntax check for the new C++ entry point
- Linked and ran the entry point against Qt with a stub asserting that `QCoreApplication::instance()` is available
- Ran the new CMake regression script with a real JPEG fixture
- `git diff --check`

A full local CMake link was not available with the minimal tools-only configuration because this repository only adds the native `drawdance_client` target when the client or server is enabled. The upstream Windows tools matrix is the authoritative end-to-end build and regression gate. `cargo fmt --all -- --check` also reports a pre-existing ordering difference in `src/drawdance/rust/msg/mod.rs`; this PR does not modify Rust sources.

## Formalities

* Is the code new or is it based on another project? If it's the latter, explain where so we can double-check the licenses.

The code is new and uses existing Qt and Drawpile APIs already present in this repository.

* Did you write the code yourself or was any AI-assistance or similar used? If it's the latter, describe what.

OpenAI Codex was used to investigate the issue, draft the entry-point change and regression test, and run validation. I reviewed the resulting diff and validation output before submitting.